### PR TITLE
[codex] prove full species ionic speciation

### DIFF
--- a/docs/full_species_ionic_speciation_handoff.md
+++ b/docs/full_species_ionic_speciation_handoff.md
@@ -76,9 +76,60 @@ Command:
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---:|---:|---:|
 | `epcsaft_reactive_nine_activity_rebased` | 3C | true | 212.809 | 89.855 | 0.355 | 4.316 | 6.70e-14 | 0 | none | 122/168 | 160.191 | 9.64e-09 | 9.97e-09 | 4.71e-14 |
 
+## All Legacy C-Case Sweep
+
+After the single-case proof, the same nine-species activity-rebased model was run for every legacy C case in `src/mea_absorption_column/data/C_cases_data.csv`.
+
+Command:
+
+```powershell
+.\.venv\Scripts\python.exe -m mea_absorption_column.benchmark `
+  --methods scipy-bvp `
+  --thermo-models epcsaft_reactive_nine_activity_rebased `
+  --nccc-case-limit 0 `
+  --srp-case-limit 0 `
+  --staged-beds false `
+  --mesh-points 7 `
+  --tol 10 `
+  --bc-tol 0.5 `
+  --max-nodes 80 `
+  --subprocess-timeout-s 900 `
+  --output-dir analyses\nccc_validation\results\runs\full_species_ionic_all_c_cases
+```
+
+Result CSV:
+
+```text
+analyses\nccc_validation\results\runs\full_species_ionic_all_c_cases\benchmark_results.csv
+```
+
+| Case | Success | Runtime s | CO2 capture % | Capture error pct-pt | Temp RMSE K | Boundary residual | Invalid states | Domain guards | Chem cache hits | Chem cache misses | Chem solve s | Max mass residual | Max reaction residual | Max charge residual |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1C | true | 336.655 | 79.258 | -17.842 | 4.903 | 6.46e-14 | 0 | 0 | 321 | 255 | 256.648 | 9.87e-09 | 9.95e-09 | 1.85e-13 |
+| 2C | true | 289.707 | 86.651 | -5.649 | 4.749 | 2.52e-13 | 0 | 0 | 125 | 178 | 218.627 | 8.50e-09 | 9.89e-09 | 5.12e-14 |
+| 3C | true | 281.664 | 89.855 | 0.355 | 4.316 | 6.70e-14 | 0 | 0 | 122 | 168 | 211.027 | 9.64e-09 | 9.97e-09 | 4.71e-14 |
+| 4C | true | 308.746 | 94.678 | 5.778 | 7.665 | 1.48e-13 | 0 | 0 | 215 | 179 | 232.915 | 9.68e-09 | 9.93e-09 | 3.37e-13 |
+| 5C | true | 444.874 | 90.525 | 4.125 | 10.335 | 2.00e-13 | 0 | 0 | 235 | 250 | 339.182 | 9.67e-09 | 1.00e-08 | 7.62e-14 |
+| 6C | true | 420.357 | 70.549 | 10.349 | 6.102 | 9.48e-14 | 0 | 0 | 226 | 220 | 321.668 | 8.19e-09 | 9.97e-09 | 1.16e-13 |
+| 7C | true | 380.387 | 98.515 | 22.115 | 22.310 | 1.88e-13 | 0 | 0 | 307 | 204 | 287.236 | 9.85e-09 | 9.93e-09 | 1.86e-13 |
+
+Sweep summary:
+
+- Success: 7 of 7 cases.
+- Total benchmark runtime: 2462.389 s.
+- Mean runtime: 351.770 s; range: 281.664-444.874 s.
+- Mean absolute CO2 capture error: 9.459 pct-pt; maximum absolute error: 22.115 pct-pt.
+- Mean temperature RMSE: 8.626 K; maximum temperature RMSE: 22.310 K.
+- Maximum boundary residual: 2.52e-13.
+- Maximum chemistry mass residual: 9.87e-09.
+- Maximum chemistry reaction residual: 1.00e-08.
+- Maximum chemistry charge residual: 3.37e-13.
+
+This is the broadest proof so far that the full nine-species ionic speciation/activity loop can run across the legacy C-case validation set. It also makes the computational tradeoff clearer: the nine-species loop converges cleanly, but all seven loose-proof runs still required about 41 minutes total wall time on this machine.
+
 ## Interpretation
 
-The nine-species full ionic activity loop now has a clean column proof run. Compared with the prior six-species activity-rebased proof, the full species set gives almost the same case-3C capture result but increases runtime from about 129 s to about 213 s under the same loose proof settings. This strengthens the manuscript argument that activity-coupled/full-species speciation is technically feasible, but the extra species and activity loop are not an attractive default for repeated absorber simulations when the accuracy gain is small.
+The nine-species full ionic activity loop now has a clean column proof run and a complete C-case sweep. Compared with the prior six-species activity-rebased proof, the full species set gives almost the same case-3C capture result but increases runtime from about 129 s to about 213-282 s depending on the rerun context and benchmark overhead. This strengthens the manuscript argument that activity-coupled/full-species speciation is technically feasible, but the extra species and activity loop are not an attractive default for repeated absorber simulations when the accuracy gain is small.
 
 ## Validation
 

--- a/docs/full_species_ionic_speciation_handoff.md
+++ b/docs/full_species_ionic_speciation_handoff.md
@@ -1,0 +1,96 @@
+# Full Species Ionic ePC-SAFT Speciation Handoff
+
+Branch: `codex/full-species-ionic`
+
+Date: 2026-05-09
+
+## What changed
+
+- Added nine-species reactive ePC-SAFT chemical-equilibrium modes:
+  - `epcsaft_reactive_nine_activity`
+  - `epcsaft_reactive_nine_activity_converted`
+  - `epcsaft_reactive_nine_activity_rebased`
+  - `epcsaft_full_species_activity`
+  - `epcsaft_full_species_activity_converted`
+  - `epcsaft_full_species_activity_rebased`
+- The nine-species state order is:
+  - `CO2, MEA, H2O, MEAH+, MEACOO-, HCO3-, CO3^2-, H3O+, OH-`
+- The nine-species model uses the MEA-Thermodynamics reaction set:
+  - `H3O+ + OH- - 2 H2O`
+  - `H3O+ + HCO3- - CO2 - 2 H2O`
+  - `H3O+ + CO3^2- - HCO3- - H2O`
+  - `MEA + HCO3- - MEACOO- - H2O`
+  - `H3O+ + MEA - MEAH+ - H2O`
+- Ionic ePC-SAFT fugacity now uses all nine liquid species when a nine-species chemistry vector is available.
+- Existing column transport/enhancement/profile code keeps the six-species compatibility view it already expects, so the BVP state was not expanded.
+
+## Source Contract
+
+The reaction constants and balances were taken from the local MEA-Thermodynamics ionic workflow:
+
+- `C:\Users\Tanner\Documents\git\MEA-Thermodynamics\src\MEA\epcsaft_runtime.py`
+- `C:\Users\Tanner\Documents\git\MEA-Thermodynamics\src\MEA\epcsaft_ionic\model.py`
+- `C:\Users\Tanner\Documents\git\MEA-Thermodynamics\docs\ePC-SAFT\mea-ionic-regression-completion-handoff.md`
+
+Equilibrium constants use:
+
+```text
+ln K = a + b/T + c*ln(T) + d*T
+```
+
+with `T` in K. The local ePC-SAFT native solver also appends charge closure from the species charge vector, so charge is not duplicated as a material balance.
+
+## Proof Run
+
+All run commands used BLAS thread pinning:
+
+```powershell
+$env:OPENBLAS_NUM_THREADS='1'
+$env:OMP_NUM_THREADS='1'
+$env:MKL_NUM_THREADS='1'
+$env:MEA_EPCSAFT_CHEMISTRY_CACHE_X_DIGITS='4'
+$env:MEA_EPCSAFT_CHEMISTRY_CACHE_T_DIGITS='1'
+$env:MEA_EPCSAFT_CHEMISTRY_CACHE_P_ROUND_PA='100'
+$env:MEA_EPCSAFT_REACTIVE_MAX_ITERATIONS='160'
+```
+
+Command:
+
+```powershell
+.\.venv\Scripts\python.exe -m mea_absorption_column.benchmark `
+  --methods scipy-bvp `
+  --thermo-models epcsaft_reactive_nine_activity_rebased `
+  --c-case-ids 3C `
+  --nccc-case-limit 0 `
+  --srp-case-limit 0 `
+  --staged-beds false `
+  --mesh-points 7 `
+  --tol 10 `
+  --bc-tol 0.5 `
+  --max-nodes 80 `
+  --subprocess-timeout-s 900 `
+  --output-dir analyses\nccc_validation\results\runs\full_species_ionic_rebased_probe
+```
+
+| Mode | Case | Success | Runtime s | CO2 capture % | Capture error pct-pt | Temp RMSE K | Boundary residual | Invalid states | Domain guards | Chemistry cache hit/miss | Chemistry solve s | Max mass residual | Max reaction residual | Max charge residual |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---:|---:|---:|
+| `epcsaft_reactive_nine_activity_rebased` | 3C | true | 212.809 | 89.855 | 0.355 | 4.316 | 6.70e-14 | 0 | none | 122/168 | 160.191 | 9.64e-09 | 9.97e-09 | 4.71e-14 |
+
+## Interpretation
+
+The nine-species full ionic activity loop now has a clean column proof run. Compared with the prior six-species activity-rebased proof, the full species set gives almost the same case-3C capture result but increases runtime from about 129 s to about 213 s under the same loose proof settings. This strengthens the manuscript argument that activity-coupled/full-species speciation is technically feasible, but the extra species and activity loop are not an attractive default for repeated absorber simulations when the accuracy gain is small.
+
+## Validation
+
+```powershell
+$env:OPENBLAS_NUM_THREADS='1'
+$env:OMP_NUM_THREADS='1'
+$env:MKL_NUM_THREADS='1'
+.\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider tests/test_epcsaft_reactive_chemistry.py
+.\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider tests/test_thermodynamics_adapter.py -k "epcsaft or ionic"
+```
+
+Current targeted result before final commit:
+
+- `tests/test_epcsaft_reactive_chemistry.py`: `4 passed in 5.20s`
+- `tests/test_thermodynamics_adapter.py -k "epcsaft or ionic"`: `8 passed, 2 deselected in 3.05s`

--- a/src/mea_absorption_column/BVP/ABS_Column.py
+++ b/src/mea_absorption_column/BVP/ABS_Column.py
@@ -311,14 +311,17 @@ def abs_column(zi, Y_scaled, parameters, run_type='simulating', column_names=Fal
 
     elif run_type == 'saving':
         Fl_true = [Cl_true[i] * ul * A for i in range(len(Cl_true))]
+        Fl_true_report = list(Fl_true[:6])
+        Cl_true_report = list(Cl_true[:6])
+        x_true_report = list(x_true[:6])
 
         Fl_CO2, Fl_MEA, Fl_H2O = Fl
-        Fl_CO2_true, Fl_MEA_true, Fl_H2O_true, Fl_MEAH_true, Fl_MEACOO_true, Fl_HCO3_true = Fl_true
+        Fl_CO2_true, Fl_MEA_true, Fl_H2O_true, Fl_MEAH_true, Fl_MEACOO_true, Fl_HCO3_true = Fl_true_report
         Fv_CO2, Fv_H2O, Fv_N2, Fv_O2 = Fv
         Cl_CO2, Cl_MEA, Cl_H2O = Cl
-        Cl_CO2_true, Cl_MEA_true, Cl_H2O_true, Cl_MEAH_true, Cl_MEACOO_true, Cl_HCO3_true = Cl_true
+        Cl_CO2_true, Cl_MEA_true, Cl_H2O_true, Cl_MEAH_true, Cl_MEACOO_true, Cl_HCO3_true = Cl_true_report
         x_CO2, x_MEA, x_H2O = x
-        x_CO2_true, x_MEA_true, x_H2O_true, x_MEAH_true, x_MEACOO_true, x_HCO3_true = x_true
+        x_CO2_true, x_MEA_true, x_H2O_true, x_MEAH_true, x_MEACOO_true, x_HCO3_true = x_true_report
         y_CO2, y_H2O, y_N2, y_O2 = y
         Cv_CO2, Cv_H2O, Cv_N2, Cv_O2 = Cv
         DF_CO2, H_CO2_mix = CO2

--- a/src/mea_absorption_column/Run_Model.py
+++ b/src/mea_absorption_column/Run_Model.py
@@ -719,6 +719,13 @@ def _default_chemical_equilibrium_model(thermo_model):
         "epcsaft_reactive_six_activity",
         "epcsaft_reactive_six_activity_converted",
         "epcsaft_reactive_six_activity_rebased",
+        "epcsaft_reactive_nine",
+        "epcsaft_reactive_nine_activity",
+        "epcsaft_reactive_nine_activity_converted",
+        "epcsaft_reactive_nine_activity_rebased",
+        "epcsaft_full_species_activity",
+        "epcsaft_full_species_activity_converted",
+        "epcsaft_full_species_activity_rebased",
     }:
         return normalized
     return "legacy"

--- a/src/mea_absorption_column/Thermodynamics/Chemical_Equilibrium.py
+++ b/src/mea_absorption_column/Thermodynamics/Chemical_Equilibrium.py
@@ -20,11 +20,27 @@ from mea_absorption_column.Thermodynamics.thermo_models import (
 
 
 SPECIES_6 = ("CO2", "MEA", "H2O", "MEAH+", "MEACOO-", "HCO3-")
+SPECIES_9 = ("CO2", "MEA", "H2O", "MEAH+", "MEACOO-", "HCO3-", "CO3^2-", "H3O+", "OH-")
 REACTIONS_6 = (
     {"CO2": -1.0, "MEA": -2.0, "MEAH+": 1.0, "MEACOO-": 1.0},
     {"CO2": -1.0, "MEA": -1.0, "H2O": -1.0, "MEAH+": 1.0, "HCO3-": 1.0},
 )
 REACTION_NAMES_6 = ("carbamate", "bicarbonate")
+REACTION_CONSTANTS_9 = {
+    "R1_water_autoionization": (132.899, -13445.9, -22.4773, 0.0),
+    "R2_CO2_to_HCO3": (231.465, -12092.1, -36.7816, 0.0),
+    "R3_HCO3_to_CO3": (216.049, -12431.0, -35.4891, 0.0),
+    "R4_MEACOO_hydrolysis": (-1.8652, -1543.3, 0.0, 0.0),
+    "R5_MEAH_dissociation": (2.1211, -8189.38, 0.0, -0.007484),
+}
+REACTIONS_9 = (
+    {"H2O": -2.0, "H3O+": 1.0, "OH-": 1.0},
+    {"CO2": -1.0, "H2O": -2.0, "HCO3-": 1.0, "H3O+": 1.0},
+    {"H2O": -1.0, "HCO3-": -1.0, "CO3^2-": 1.0, "H3O+": 1.0},
+    {"MEA": 1.0, "H2O": -1.0, "MEACOO-": -1.0, "HCO3-": 1.0},
+    {"MEA": 1.0, "H2O": -1.0, "MEAH+": -1.0, "H3O+": 1.0},
+)
+REACTION_NAMES_9 = tuple(REACTION_CONSTANTS_9)
 EPCSAFT_CHEMISTRY_CACHE_T_DIGITS = int(os.environ.get("MEA_EPCSAFT_CHEMISTRY_CACHE_T_DIGITS", "2"))
 EPCSAFT_CHEMISTRY_CACHE_X_DIGITS = int(os.environ.get("MEA_EPCSAFT_CHEMISTRY_CACHE_X_DIGITS", "6"))
 EPCSAFT_CHEMISTRY_CACHE_P_ROUND_PA = float(os.environ.get("MEA_EPCSAFT_CHEMISTRY_CACHE_P_ROUND_PA", "10.0"))
@@ -307,10 +323,54 @@ def chemical_equilibrium_with_model(
             calibrate_activity_to_legacy=True,
             diagnostics=diagnostics,
         )
+    if normalized_model in {
+        "epcsaft_reactive_nine",
+        "epcsaft_reactive_nine_activity",
+        "epcsaft_nine_activity",
+        "epcsaft_full_species_activity",
+    }:
+        return epcsaft_reactive_chemical_equilibrium(
+            Fl,
+            Tl,
+            P=P,
+            standard_state="mole_fraction_activity",
+            species_set="nine",
+            calibrate_activity_to_legacy=False,
+            diagnostics=diagnostics,
+        )
+    if normalized_model in {
+        "epcsaft_reactive_nine_activity_rebased",
+        "epcsaft_nine_activity_rebased",
+        "epcsaft_full_species_activity_rebased",
+    }:
+        return epcsaft_reactive_chemical_equilibrium(
+            Fl,
+            Tl,
+            P=P,
+            standard_state="mole_fraction_activity",
+            species_set="nine",
+            calibrate_activity_to_legacy=True,
+            diagnostics=diagnostics,
+        )
+    if normalized_model in {
+        "epcsaft_reactive_nine_activity_converted",
+        "epcsaft_nine_activity_converted",
+        "epcsaft_full_species_activity_converted",
+    }:
+        return epcsaft_reactive_chemical_equilibrium(
+            Fl,
+            Tl,
+            P=P,
+            standard_state="mole_fraction_activity",
+            log_k_basis="concentration_to_mole_fraction",
+            species_set="nine",
+            calibrate_activity_to_legacy=False,
+            diagnostics=diagnostics,
+        )
     raise ValueError(
         "Choose legacy, epcsaft_reactive_six_concentration, "
         "epcsaft_reactive_six_activity, epcsaft_reactive_six_activity_converted, "
-        "or epcsaft_reactive_six_activity_rebased."
+        "epcsaft_reactive_six_activity_rebased, or epcsaft_reactive_nine_activity_rebased."
     )
 
 
@@ -321,9 +381,12 @@ def epcsaft_reactive_chemical_equilibrium(
     P=101325.0,
     standard_state="concentration",
     log_k_basis="native",
+    species_set="six",
     calibrate_activity_to_legacy=False,
     diagnostics=None,
 ):
+    species_set = str(species_set).lower()
+    species, reaction_names, reaction_rows = _reactive_species_contract(species_set)
     apparent_x = _apparent_liquid_mole_fraction(Fl)
     pressure = float(P)
     temperature = float(Tl)
@@ -334,6 +397,7 @@ def epcsaft_reactive_chemical_equilibrium(
         standard_state,
         log_k_basis,
         calibrate_activity_to_legacy,
+        species_set,
     )
     cache = getattr(epcsaft_reactive_chemical_equilibrium, "cache", {})
     cached = cache.get(cache_key)
@@ -343,10 +407,10 @@ def epcsaft_reactive_chemical_equilibrium(
     _increment_diagnostic(diagnostics, "epcsaft_chemistry_cache_misses")
 
     epcsaft = _epcsaft_module()
-    initial_x = _initial_epcsaft_chemistry_guess(apparent_x, temperature)
-    mixture = _epcsaft_six_mixture(epcsaft, temperature, initial_x)
+    initial_x = _initial_epcsaft_chemistry_guess(apparent_x, temperature, species_set=species_set)
+    mixture = _epcsaft_reactive_mixture(epcsaft, temperature, initial_x, species)
     if calibrate_activity_to_legacy:
-        log_k = _log_k_from_activity_state(mixture, temperature, pressure, initial_x)
+        log_k = _log_k_from_activity_state(mixture, temperature, pressure, initial_x, species, reaction_rows)
     else:
         log_k = _epcsaft_reaction_log_constants(
             apparent_x,
@@ -354,6 +418,7 @@ def epcsaft_reactive_chemical_equilibrium(
             pressure,
             standard_state=standard_state,
             log_k_basis=log_k_basis,
+            species_set=species_set,
         )
     reactions = [
         epcsaft.ReactionDefinition(
@@ -362,25 +427,17 @@ def epcsaft_reactive_chemical_equilibrium(
             name=name,
             standard_state=standard_state,
         )
-        for reaction, value, name in zip(REACTIONS_6, log_k, REACTION_NAMES_6)
+        for reaction, value, name in zip(reaction_rows, log_k, reaction_names)
     ]
     options = _reactive_speciation_options(epcsaft)
     started = time.perf_counter()
     result = epcsaft.solve_reactive_speciation(
-        species=list(SPECIES_6),
+        species=list(species),
         mixture_factory=lambda x, T, P: mixture,
         T=temperature,
         P=pressure,
-        balances={
-            "amine_total": {"MEA": 1.0, "MEAH+": 1.0, "MEACOO-": 1.0},
-            "carbon_total": {"CO2": 1.0, "MEACOO-": 1.0, "HCO3-": 1.0},
-            "water_total": {"H2O": 1.0},
-        },
-        totals={
-            "amine_total": float(apparent_x[1]),
-            "carbon_total": float(apparent_x[0]),
-            "water_total": float(apparent_x[2]),
-        },
+        balances=_reactive_balances(species_set),
+        totals=_reactive_totals(apparent_x, species_set),
         reactions=reactions,
         initial_x=initial_x,
         options=options,
@@ -402,7 +459,7 @@ def epcsaft_reactive_chemical_equilibrium(
                 f"ePC-SAFT reactive speciation did not converge: {result.message}",
             )
             raise RuntimeError(f"ePC-SAFT reactive speciation failed: {result.message}")
-    x_true = np.asarray([float(result.x[name]) for name in SPECIES_6], dtype=float)
+    x_true = np.asarray([float(result.x[name]) for name in species], dtype=float)
     x_true = np.maximum(x_true, 1.0e-30)
     x_true = x_true / float(np.sum(x_true))
     rho_mol_l, _, _ = density(temperature, apparent_x[:3], pressure, phase="liquid")
@@ -410,6 +467,46 @@ def epcsaft_reactive_chemical_equilibrium(
     cache[cache_key] = (Cl_true.copy(), x_true.copy())
     epcsaft_reactive_chemical_equilibrium.cache = cache
     return Cl_true, x_true
+
+
+def _reactive_species_contract(species_set):
+    if species_set == "six":
+        return SPECIES_6, REACTION_NAMES_6, REACTIONS_6
+    if species_set == "nine":
+        return SPECIES_9, REACTION_NAMES_9, REACTIONS_9
+    raise ValueError(f"Unknown ePC-SAFT reactive species set: {species_set!r}")
+
+
+def _reactive_balances(species_set):
+    if species_set == "six":
+        return {
+            "amine_total": {"MEA": 1.0, "MEAH+": 1.0, "MEACOO-": 1.0},
+            "carbon_total": {"CO2": 1.0, "MEACOO-": 1.0, "HCO3-": 1.0},
+            "water_total": {"H2O": 1.0},
+        }
+    if species_set == "nine":
+        return {
+            "carbon_total": {"CO2": 1.0, "MEACOO-": 1.0, "HCO3-": 1.0, "CO3^2-": 1.0},
+            "amine_total": {"MEA": 1.0, "MEAH+": 1.0, "MEACOO-": 1.0},
+            "water_total": {"H2O": 1.0, "HCO3-": 1.0, "CO3^2-": 1.0, "H3O+": 1.0, "OH-": 1.0},
+        }
+    raise ValueError(f"Unknown ePC-SAFT reactive species set: {species_set!r}")
+
+
+def _reactive_totals(apparent_x, species_set):
+    if species_set == "six":
+        return {
+            "amine_total": float(apparent_x[1]),
+            "carbon_total": float(apparent_x[0]),
+            "water_total": float(apparent_x[2]),
+        }
+    if species_set == "nine":
+        return {
+            "carbon_total": float(apparent_x[0]),
+            "amine_total": float(apparent_x[1]),
+            "water_total": float(apparent_x[2]),
+        }
+    raise ValueError(f"Unknown ePC-SAFT reactive species set: {species_set!r}")
 
 
 def legacy_log_constants(temperature_K):
@@ -422,6 +519,14 @@ def legacy_log_constants(temperature_K):
     )
 
 
+def full_species_log_constants(temperature_K):
+    T = float(temperature_K)
+    values = []
+    for a, b, c, d in REACTION_CONSTANTS_9.values():
+        values.append(float(a + b / T + c * np.log(T) + d * T))
+    return tuple(values)
+
+
 def _epcsaft_reaction_log_constants(
     apparent_x,
     temperature,
@@ -429,8 +534,15 @@ def _epcsaft_reaction_log_constants(
     *,
     standard_state,
     log_k_basis,
+    species_set="six",
 ):
-    log_k = np.asarray(legacy_log_constants(temperature), dtype=float)
+    species, _, reactions = _reactive_species_contract(species_set)
+    if species_set == "six":
+        log_k = np.asarray(legacy_log_constants(temperature), dtype=float)
+    elif species_set == "nine":
+        log_k = np.asarray(full_species_log_constants(temperature), dtype=float)
+    else:
+        raise ValueError(f"Unknown ePC-SAFT reactive species set: {species_set!r}")
     if str(log_k_basis).lower() in {"native", "concentration"}:
         return tuple(float(value) for value in log_k)
     if str(log_k_basis).lower() != "concentration_to_mole_fraction":
@@ -441,7 +553,7 @@ def _epcsaft_reaction_log_constants(
     rho_mol_l, _, _ = density(float(temperature), np.asarray(apparent_x[:3], dtype=float), float(pressure), phase="liquid")
     rho_mol_l = max(float(rho_mol_l), 1.0e-30)
     converted = []
-    for reaction, value in zip(REACTIONS_6, log_k):
+    for reaction, value in zip(reactions, log_k):
         stoich_sum = float(sum(reaction.values()))
         converted.append(float(value - stoich_sum * math.log(rho_mol_l)))
     return tuple(converted)
@@ -456,14 +568,33 @@ def _apparent_liquid_mole_fraction(Fl):
     return flows / total
 
 
-def _initial_epcsaft_chemistry_guess(apparent_x, temperature):
+def _initial_epcsaft_chemistry_guess(apparent_x, temperature, *, species_set="six"):
     try:
         if not hasattr(epcsaft_reactive_chemical_equilibrium, "legacy_guess_cache"):
             epcsaft_reactive_chemical_equilibrium.legacy_guess_cache = {}
         legacy_Cl, legacy_x = chemical_equilibrium(list(apparent_x[:3]), float(temperature))
-        return np.asarray(legacy_x, dtype=float)
+        legacy_x = np.asarray(legacy_x, dtype=float)
+        if species_set == "six":
+            return legacy_x
+        if species_set == "nine":
+            seed = np.zeros(len(SPECIES_9), dtype=float)
+            seed[: len(SPECIES_6)] = legacy_x
+            seed[SPECIES_9.index("CO3^2-")] = 1.0e-12
+            seed[SPECIES_9.index("OH-")] = 1.0e-12
+            seed[SPECIES_9.index("H3O+")] = 3.0e-12
+            seed = np.maximum(seed, 1.0e-14)
+            return seed / float(np.sum(seed))
+        raise ValueError(f"Unknown ePC-SAFT reactive species set: {species_set!r}")
     except Exception:
-        seed = np.asarray([apparent_x[0], apparent_x[1], apparent_x[2], 1.0e-8, 1.0e-8, 1.0e-8], dtype=float)
+        if species_set == "six":
+            seed = np.asarray([apparent_x[0], apparent_x[1], apparent_x[2], 1.0e-8, 1.0e-8, 1.0e-8], dtype=float)
+        elif species_set == "nine":
+            seed = np.asarray(
+                [apparent_x[0], apparent_x[1], apparent_x[2], 1.0e-8, 1.0e-8, 1.0e-8, 1.0e-12, 3.0e-12, 1.0e-12],
+                dtype=float,
+            )
+        else:
+            raise ValueError(f"Unknown ePC-SAFT reactive species set: {species_set!r}")
         seed = np.maximum(seed, 1.0e-14)
         return seed / float(np.sum(seed))
 
@@ -475,27 +606,28 @@ def _epcsaft_module():
     return epcsaft
 
 
-def _epcsaft_six_mixture(epcsaft, temperature, x):
+def _epcsaft_reactive_mixture(epcsaft, temperature, x, species):
     dataset = Path(MEA_THERMODYNAMICS_EPCSAFT_DATASET)
     user_options = epcsaft_runtime_user_options() or None
     return epcsaft.ePCSAFTMixture.from_dataset(
         str(dataset),
-        list(SPECIES_6),
+        list(species),
         np.asarray(x, dtype=float),
         float(temperature),
         user_options=user_options,
     )
 
 
-def _log_k_from_activity_state(mixture, temperature, pressure, x):
+def _log_k_from_activity_state(mixture, temperature, pressure, x, species, reactions):
     state = mixture.state(T=float(temperature), P=float(pressure), x=np.asarray(x, dtype=float), phase="liq")
-    gamma = state.activity_coefficient(species=list(SPECIES_6))
+    gamma = state.activity_coefficient(species=list(species))
+    index = {name: idx for idx, name in enumerate(species)}
     values = []
-    for reaction in REACTIONS_6:
+    for reaction in reactions:
         total = 0.0
-        for species, coefficient in reaction.items():
-            idx = SPECIES_6.index(species)
-            activity = max(float(x[idx]) * float(gamma[species]), 1.0e-300)
+        for species_name, coefficient in reaction.items():
+            idx = index[species_name]
+            activity = max(float(x[idx]) * float(gamma[species_name]), 1.0e-300)
             total += float(coefficient) * math.log(activity)
         values.append(float(total))
     return tuple(values)
@@ -508,9 +640,11 @@ def _epcsaft_chemistry_cache_key(
     standard_state,
     log_k_basis,
     calibrate_activity_to_legacy,
+    species_set,
 ):
     pressure_increment = max(EPCSAFT_CHEMISTRY_CACHE_P_ROUND_PA, 1.0e-12)
     return (
+        str(species_set),
         str(standard_state),
         str(log_k_basis),
         bool(calibrate_activity_to_legacy),

--- a/src/mea_absorption_column/Thermodynamics/thermo_models.py
+++ b/src/mea_absorption_column/Thermodynamics/thermo_models.py
@@ -22,7 +22,9 @@ EPCSAFT_BUILD_DIRS = (
     EPCSAFT_SOURCE_ROOT / "build" / f"cp{sys.version_info.major}{sys.version_info.minor}-cp{sys.version_info.major}{sys.version_info.minor}-win_amd64",
 )
 SPECIES = ["CO2", "MEA", "H2O"]
-IONIC_LIQUID_SPECIES = ["CO2", "MEA", "H2O", "MEAH+", "MEACOO-", "HCO3-"]
+IONIC_LIQUID_SPECIES_6 = ["CO2", "MEA", "H2O", "MEAH+", "MEACOO-", "HCO3-"]
+IONIC_LIQUID_SPECIES_9 = ["CO2", "MEA", "H2O", "MEAH+", "MEACOO-", "HCO3-", "CO3^2-", "H3O+", "OH-"]
+IONIC_LIQUID_SPECIES = IONIC_LIQUID_SPECIES_6
 CO2_INDEX = 0
 MEA_INDEX = 1
 H2O_INDEX = 2
@@ -122,16 +124,23 @@ def neutral_vapor_composition(y) -> np.ndarray:
 
 def ionic_liquid_composition(x_true) -> np.ndarray:
     x_arr = np.asarray(x_true, dtype=float)
-    if x_arr.size < len(IONIC_LIQUID_SPECIES):
+    species = _ionic_species_for_size(x_arr.size)
+    if x_arr.size < len(species):
         raise ValueError(
-            f"ePC-SAFT ionic liquid composition requires {len(IONIC_LIQUID_SPECIES)} species, got {x_arr.size}."
+            f"ePC-SAFT ionic liquid composition requires {len(species)} species, got {x_arr.size}."
         )
-    ionic = np.asarray(x_arr[: len(IONIC_LIQUID_SPECIES)], dtype=float)
+    ionic = np.asarray(x_arr[: len(species)], dtype=float)
     ionic = np.maximum(ionic, COMPOSITION_FLOOR)
     total = float(ionic.sum())
     if not math.isfinite(total) or total <= 0.0:
         raise ValueError("Ionic liquid composition must have a positive finite sum.")
     return ionic / total
+
+
+def _ionic_species_for_size(size: int) -> list[str]:
+    if int(size) >= len(IONIC_LIQUID_SPECIES_9):
+        return IONIC_LIQUID_SPECIES_9
+    return IONIC_LIQUID_SPECIES_6
 
 
 def ensure_epcsaft_importable():
@@ -373,11 +382,15 @@ def _pressure_state_with_optional_rho_guess(mixture, T, P, composition, phase, m
 
 
 def epcsaft_phi_co2(T, P, composition, phase, cache=True, mixture_kind="neutral") -> float:
-    species_key = tuple(IONIC_LIQUID_SPECIES if mixture_kind == "ionic" else SPECIES)
+    composition_arr = np.asarray(composition, dtype=float)
+    if mixture_kind == "ionic":
+        species_key = tuple(_ionic_species_for_size(composition_arr.size))
+    else:
+        species_key = tuple(SPECIES)
     user_options_json = "{}"
     if mixture_kind in {"ionic", "external_neutral"}:
         user_options_json = _canonical_user_options_json(epcsaft_runtime_user_options())
-    key = (str(mixture_kind), user_options_json, *_epcsaft_cache_key(T, P, composition, phase))
+    key = (str(mixture_kind), user_options_json, *_epcsaft_cache_key(T, P, composition_arr, phase))
     if cache and key in _EPCSAFT_PHI_CACHE:
         _EPCSAFT_CACHE_STATS["epcsaft_cache_hits"] += 1
         return _EPCSAFT_PHI_CACHE[key]
@@ -509,6 +522,13 @@ def compute_fugacity(
         "epcsaft_reactive_six_activity",
         "epcsaft_reactive_six_activity_converted",
         "epcsaft_reactive_six_activity_rebased",
+        "epcsaft_reactive_nine",
+        "epcsaft_reactive_nine_activity",
+        "epcsaft_reactive_nine_activity_converted",
+        "epcsaft_reactive_nine_activity_rebased",
+        "epcsaft_full_species_activity",
+        "epcsaft_full_species_activity_converted",
+        "epcsaft_full_species_activity_rebased",
     }:
         blend = float(np.clip(epcsaft_fugacity_blend, 0.0, 1.0))
         epcsaft_values = epcsaft_ionic_fugacity(y, x_true, Tl, Tv, P, P_sat_H2O)

--- a/src/mea_absorption_column/Transport/Enhancement_Factor.py
+++ b/src/mea_absorption_column/Transport/Enhancement_Factor.py
@@ -11,7 +11,7 @@ def enhancement_factor(Tl, Cl_true, y_CO2, P,
                        Dl_CO2, Dl_MEA, Dl_ion, E_type='explicit', diagnostics=None):
     enable_enhancement_factor = True
 
-    Cl_CO2_true, Cl_MEA_true, Cl_H2O_true, Cl_MEAH_true, Cl_MEACOO_true, Cl_HCO3_true = Cl_true
+    Cl_CO2_true, Cl_MEA_true, Cl_H2O_true, Cl_MEAH_true, Cl_MEACOO_true, Cl_HCO3_true = Cl_true[:6]
     Cl_CO2_true = Cl_CO2_true / 1.04542981654115
     Dl_MEAH = Dl_ion
     Dl_MEACOO = Dl_ion

--- a/src/mea_absorption_column/benchmark.py
+++ b/src/mea_absorption_column/benchmark.py
@@ -621,6 +621,13 @@ def _default_chemical_equilibrium_model(thermo_model):
         "epcsaft_reactive_six_activity",
         "epcsaft_reactive_six_activity_converted",
         "epcsaft_reactive_six_activity_rebased",
+        "epcsaft_reactive_nine",
+        "epcsaft_reactive_nine_activity",
+        "epcsaft_reactive_nine_activity_converted",
+        "epcsaft_reactive_nine_activity_rebased",
+        "epcsaft_full_species_activity",
+        "epcsaft_full_species_activity_converted",
+        "epcsaft_full_species_activity_rebased",
     }:
         return normalized
     return "legacy"

--- a/tests/test_epcsaft_reactive_chemistry.py
+++ b/tests/test_epcsaft_reactive_chemistry.py
@@ -9,6 +9,8 @@ from mea_absorption_column.Thermodynamics.thermo_models import (
     ensure_epcsaft_importable,
 )
 
+SPECIES_9 = ("CO2", "MEA", "H2O", "MEAH+", "MEACOO-", "HCO3-", "CO3^2-", "H3O+", "OH-")
+
 
 def _requires_reactive_epcsaft_dataset():
     try:
@@ -83,3 +85,27 @@ def test_epcsaft_reactive_six_activity_converted_uses_concentration_basis_units(
     assert converted_x[0] < activity_x[0]
     assert converted_x[0] > legacy_x[0]
     assert abs(converted_x[4] - legacy_x[4]) < abs(activity_x[4] - legacy_x[4])
+
+
+def test_epcsaft_reactive_nine_activity_rebased_solves_case_3c_state():
+    _requires_reactive_epcsaft_dataset()
+    Fl, Tl, P = _case_3c_liquid_state()
+    diagnostics = {}
+
+    Cl_true, x_true = chemical_equilibrium_with_model(
+        Fl,
+        Tl,
+        model="epcsaft_reactive_nine_activity_rebased",
+        P=P,
+        diagnostics=diagnostics,
+    )
+
+    np.testing.assert_allclose(np.sum(x_true), 1.0, atol=1.0e-12)
+    assert len(x_true) == len(SPECIES_9)
+    assert len(Cl_true) == len(SPECIES_9)
+    assert diagnostics["epcsaft_chemistry_max_mass_residual"] < 1.0e-6
+    assert diagnostics["epcsaft_chemistry_max_reaction_residual"] < 1.0e-6
+    assert diagnostics["epcsaft_chemistry_max_charge_residual"] < 1.0e-6
+    assert x_true[SPECIES_9.index("H3O+")] > 0.0
+    assert x_true[SPECIES_9.index("OH-")] > 0.0
+    assert x_true[SPECIES_9.index("CO3^2-")] > 0.0

--- a/tests/test_thermodynamics_adapter.py
+++ b/tests/test_thermodynamics_adapter.py
@@ -10,6 +10,7 @@ from mea_absorption_column.Thermodynamics.Fugacity import fugacity
 from mea_absorption_column.Thermodynamics.thermo_models import (
     EPCSAFT_SOURCE_ROOT,
     IONIC_LIQUID_SPECIES,
+    IONIC_LIQUID_SPECIES_9,
     MEA_THERMODYNAMICS_EPCSAFT_DATASET,
     build_epcsaft_params,
     ensure_epcsaft_importable,
@@ -185,3 +186,21 @@ def test_ionic_epcsaft_state_uses_ion_and_born_contribution_terms():
     assert abs(float(ares["terms"]["born"])) > 1.0e-8
     assert np.any(np.abs(np.asarray(lnfug["terms"]["ion"], dtype=float)) > 1.0e-8)
     assert np.any(np.abs(np.asarray(lnfug["terms"]["born"], dtype=float)) > 1.0e-8)
+
+
+def test_full_species_ionic_epcsaft_state_uses_all_nine_species():
+    try:
+        ensure_epcsaft_importable()
+    except RuntimeError as exc:
+        pytest.skip(f"external ePC-SAFT native extension unavailable: {exc}")
+
+    mixture = epcsaft_dataset_mixture(tuple(IONIC_LIQUID_SPECIES_9), 323.2)
+    composition = np.array([0.02, 0.23, 0.62, 0.06, 0.05, 0.01, 1.0e-6, 2.0e-6, 1.0e-6], dtype=float)
+    composition /= composition.sum()
+    state = mixture.state(T=323.15, x=composition, P=109500.0, phase="liq")
+    phi = state.fugacity_coefficient(natural_log=True)
+    lnfug = state.fugacity_coefficient(natural_log=True, return_contribution_terms=True)
+
+    assert len(phi) == len(IONIC_LIQUID_SPECIES_9)
+    assert len(lnfug["terms"]["ion"]) == len(IONIC_LIQUID_SPECIES_9)
+    assert len(lnfug["terms"]["born"]) == len(IONIC_LIQUID_SPECIES_9)


### PR DESCRIPTION
## Summary
- adds nine-species full ionic ePC-SAFT reactive speciation modes for the MEA column
- routes nine-species chemistry into full nine-species ionic liquid fugacity while keeping the legacy six-species view for column enhancement/profile compatibility
- adds targeted nine-species chemistry and adapter tests plus a reproducibility handoff report
- documents a complete legacy C-case sweep for `epcsaft_reactive_nine_activity_rebased`

## Full C-case proof
All legacy C cases in `src/mea_absorption_column/data/C_cases_data.csv` were run with:

```powershell
.\.venv\Scripts\python.exe -m mea_absorption_column.benchmark `
  --methods scipy-bvp `
  --thermo-models epcsaft_reactive_nine_activity_rebased `
  --nccc-case-limit 0 `
  --srp-case-limit 0 `
  --staged-beds false `
  --mesh-points 7 `
  --tol 10 `
  --bc-tol 0.5 `
  --max-nodes 80 `
  --subprocess-timeout-s 900 `
  --output-dir analyses\nccc_validation\results\runs\full_species_ionic_all_c_cases
```

| Case | Success | Runtime s | CO2 capture % | Capture error pct-pt | Temp RMSE K | Boundary residual | Invalid states | Domain guards | Chem solve s | Max mass residual | Max reaction residual | Max charge residual |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1C | true | 336.655 | 79.258 | -17.842 | 4.903 | 6.46e-14 | 0 | 0 | 256.648 | 9.87e-09 | 9.95e-09 | 1.85e-13 |
| 2C | true | 289.707 | 86.651 | -5.649 | 4.749 | 2.52e-13 | 0 | 0 | 218.627 | 8.50e-09 | 9.89e-09 | 5.12e-14 |
| 3C | true | 281.664 | 89.855 | 0.355 | 4.316 | 6.70e-14 | 0 | 0 | 211.027 | 9.64e-09 | 9.97e-09 | 4.71e-14 |
| 4C | true | 308.746 | 94.678 | 5.778 | 7.665 | 1.48e-13 | 0 | 0 | 232.915 | 9.68e-09 | 9.93e-09 | 3.37e-13 |
| 5C | true | 444.874 | 90.525 | 4.125 | 10.335 | 2.00e-13 | 0 | 0 | 339.182 | 9.67e-09 | 1.00e-08 | 7.62e-14 |
| 6C | true | 420.357 | 70.549 | 10.349 | 6.102 | 9.48e-14 | 0 | 0 | 321.668 | 8.19e-09 | 9.97e-09 | 1.16e-13 |
| 7C | true | 380.387 | 98.515 | 22.115 | 22.310 | 1.88e-13 | 0 | 0 | 287.236 | 9.85e-09 | 9.93e-09 | 1.86e-13 |

Sweep summary: 7/7 converged, 2462.389 s total runtime, 351.770 s mean runtime, max boundary residual 2.52e-13, max chemistry mass residual 9.87e-09, max reaction residual 1.00e-08, max charge residual 3.37e-13.

## Single-case baseline proof
The earlier 3C proof run is retained in `docs/full_species_ionic_speciation_handoff.md`: runtime 212.809 s, CO2 capture 89.855%, capture error 0.355 pct-pt, temperature RMSE 4.316 K, boundary residual 6.70e-14, zero invalid/guard states, and chemistry residuals near 1e-8.

## Interpretation for manuscript update
These results should be used to support a manuscript statement that the full nine-species ionic speciation/activity loop can converge for the validation C cases and can produce clean column runs. The same evidence also shows why it should not be the default repeated-simulation assumption: it is very slow, and the added activity/speciation detail gives little practical capture-accuracy improvement for the best-behaved proof case relative to faster simplified chemistry assumptions.

## Validation
- `OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 .\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider tests\test_epcsaft_reactive_chemistry.py` -> 4 passed
- `OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 .\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider tests\test_thermodynamics_adapter.py -k "epcsaft or ionic"` -> 8 passed, 2 deselected