### PR TITLE
[codex] Add legacy SRP LHC probe evidence

### DIFF
--- a/analyses/legacy_srp_lhc_probe/README.md
+++ b/analyses/legacy_srp_lhc_probe/README.md
@@ -1,0 +1,50 @@
+# Legacy SRP-LHC Probe
+
+This analysis checks how the `legacy/main-legacy` model behaves on the
+25-row SRP Latin-hypercube design without modifying the legacy branch itself.
+The committed CSV files are the paper-facing evidence from that probe.
+
+The runner adapts `LHC_design_w_SRP_cases.csv` to the column order expected by
+the legacy `run_model(...)` API and records per-row success, capture, runtime,
+and timeout status.  The default geometry mode is `srp`, which patches the
+legacy converter's `NCCC` geometry dictionary entry at runtime to use the
+already-present `SRP` dimensions.  Use `--geometry legacy-nccc` to reproduce
+the converter with its original hardwired dimensions.
+
+The legacy code imports `pcsaft` at module import time, but the active fugacity
+mode in `Thermodynamics/Fugacity.py` is `ideal`.  The runner therefore installs
+a process-local shim for the unused `pcsaft` import so the old ideal-Henry path
+can be tested without requiring the broken legacy `pcsaft` build.
+
+The runner has two vapor-water modes:
+
+- `explicit`: use the `y_H2O` values stored in `LHC_design_w_SRP_cases.csv`.
+- `legacy-ratio`: reproduce the old converter behavior,
+  `y_H2O = 0.9626010166*y_CO2`.
+
+Example:
+
+```powershell
+# Validate committed probe artifacts from a current main checkout.
+.\.venv\Scripts\python.exe analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py --validate-results-only
+
+# Re-run the probe from a legacy-compatible checkout.
+.\.venv\Scripts\python.exe analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py --methods single --geometry srp --water-modes explicit legacy-ratio --timeout-s 60
+```
+
+Observed result in this probe:
+
+- `single`/shooting with SRP geometry and `legacy-ratio` vapor water solved all
+  25 SRP-LHC rows with median model runtime near 0.85 s.
+- `single`/shooting with SRP geometry and explicit SRP-LHC vapor water solved
+  20 of 25 rows with median successful model runtime near 0.78 s.
+- The five explicit-water failures are runs 1, 9, 10, 17, and 23.  A
+  runner-local bounded least-squares shooting probe was also tested on those
+  rows and did not recover them; the failures are tied to non-finite physical
+  states in the legacy transport/thermal path under the drier SRP-LHC vapor
+  inlet, not simply the Krylov root method.
+- The manuscript-level interpretation should be that shooting is fast for
+  smoother SRP-like cases, finite difference can be useful as an intermediate
+  method, and collocation remains the more defensible reference method for
+  NCCC-style validation because it handles coupled boundary conditions and
+  sharper thermal behavior more systematically.

--- a/analyses/legacy_srp_lhc_probe/results/bounded_failed_rows/legacy_srp_lhc_matrix.csv
+++ b/analyses/legacy_srp_lhc_probe/results/bounded_failed_rows/legacy_srp_lhc_matrix.csv
@@ -1,0 +1,34 @@
+run,method,geometry,water_mode,status,success,capture_pct,runtime_s,message,L,V,L_G,alpha,w_MEA,y_CO2,y_H2O_input,y_H2O_legacy_converter,y_H2O_used,Tl_K,Tv_K,wall_runtime_s,timeout_s
+1,single-bounded,srp,explicit,solver_failure,False,,1.228559900000164,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / Tc_MEA) + c4_MEA * (Tl / Tc_MEA) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Pressure_Drop.py:30: RuntimeWarning: divide by zero encountered in scalar divide
+  ΔP_H = Ψ_L * a_p / (ϵ - h_L) ** 3 ** Fv ** 2 / 2 * 1 / K",28.64360773540634,3.777578223070945,7.58253199377055,0.2856469999645027,0.2918733806302769,0.1673103512648684,0.0158094828065687,0.1610531142152654,0.0158094828065687,311.3692878203966,319.4556992586939,2.68967930000008,45.0
+9,single-bounded,srp,explicit,solver_failure,False,,1.263893399999688,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:25: RuntimeWarning: invalid value encountered in scalar power
+  Ha = (k2 * Cl_MEA_true * Dl_CO2) ** .5 / kl_CO2
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Pressure_Drop.py:30: RuntimeWarning: divide by zero encountered in scalar divide
+  ΔP_H = Ψ_L * a_p / (ϵ - h_L) ** 3 ** Fv ** 2 / 2 * 1 / K
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 ",27.83654811754617,3.672922774553986,7.578854723109838,0.2938359055490854,0.2909238582807239,0.1821079360336417,0.0118964905861627,0.17529728435691128,0.0118964905861627,315.74153656601663,320.8708222432993,2.7887202000001707,45.0
+10,single-bounded,srp,explicit,solver_failure,False,,1.2826203999998143,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Pressure_Drop.py:30: RuntimeWarning: divide by zero encountered in scalar divide
+  ΔP_H = Ψ_L * a_p / (ϵ - h_L) ** 3 ** Fv ** 2 / 2 * 1 / K
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / Tc_MEA) + c4_MEA * (Tl / Tc_MEA) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:101: RuntimeWarning: i",26.54225993893724,3.683581415948169,7.205558108210064,0.2840744221649599,0.3093693864794469,0.1783333963179011,0.0133697228263885,0.1716639085893423,0.0133697228263885,314.5064803131476,321.2851857303846,2.8543946999998298,45.0
+17,single-bounded,srp,explicit,solver_failure,False,,1.3123727000001963,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:25: RuntimeWarning: invalid value encountered in scalar power
+  Ha = (k2 * Cl_MEA_true * Dl_CO2) ** .5 / kl_CO2
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Pressure_Drop.py:30: RuntimeWarning: divide by zero encountered in scalar divide
+  ΔP_H = Ψ_L * a_p / (ϵ - h_L) ** 3 ** Fv ** 2 / 2 * 1 / K
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / Tc_MEA) + c4_MEA * (Tl / Tc_MEA) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:101: RuntimeWarning: invalid value encountered ",30.56293074746814,3.998529518589053,7.643542608697002,0.2709035761091949,0.2878818444877855,0.1724617903463623,0.014750288343327,0.1660118947120644,0.014750288343327,314.1918830188118,322.88170029126763,2.8601613000000725,45.0
+23,single-bounded,srp,explicit,solver_failure,False,,1.2940909000003558,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / Tc_MEA) + c4_MEA * (Tl / Tc_MEA) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:101: RuntimeWarning: invalid value encountered in scalar power
+  sigma_H2O = c1_H2O * (1 - Tl / Tc_H2O) ** (c2_H2O + c3_H2O * (Tl / Tc_H2O) + c4_H2O * (Tl / Tc_H2O) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\T",28.186610808100355,3.892572404345545,7.241126915618502,0.2813512937989418,0.3014263101443651,0.1750572198314629,0.015212879174635,0.16851025777293588,0.015212879174635,311.1993823860036,320.6080443100327,2.8286826999997174,45.0

--- a/analyses/legacy_srp_lhc_probe/results/bounded_failed_rows/legacy_srp_lhc_report.md
+++ b/analyses/legacy_srp_lhc_probe/results/bounded_failed_rows/legacy_srp_lhc_report.md
@@ -1,0 +1,13 @@
+# Legacy SRP-LHC Probe Results
+
+Rows tested: 5
+
+```text
+geometry water_mode         method         status  runs  median_runtime_s  median_wall_runtime_s  median_capture_pct
+     srp   explicit single-bounded solver_failure     5           1.28262               2.828683                 NaN
+```
+
+Notes:
+- `single` is the legacy shooting-method path.
+- The `srp` geometry mode patches the legacy converter's hardwired NCCC geometry to the SRP dimensions already present in `Constants.py`.
+- The legacy converter reconstructs vapor water from a fixed CO2-water ratio, so `y_H2O_input` and `y_H2O_legacy_converter` are both reported.

--- a/analyses/legacy_srp_lhc_probe/results/bounded_failed_rows/legacy_srp_lhc_summary.csv
+++ b/analyses/legacy_srp_lhc_probe/results/bounded_failed_rows/legacy_srp_lhc_summary.csv
@@ -1,0 +1,2 @@
+geometry,water_mode,method,status,runs,median_runtime_s,median_wall_runtime_s,median_capture_pct
+srp,explicit,single-bounded,solver_failure,5,1.2826203999998143,2.8286826999997174,

--- a/analyses/legacy_srp_lhc_probe/results/legacy_srp_lhc_matrix.csv
+++ b/analyses/legacy_srp_lhc_probe/results/legacy_srp_lhc_matrix.csv
@@ -1,0 +1,250 @@
+run,method,geometry,water_mode,status,success,capture_pct,runtime_s,wall_runtime_s,timeout_s,message,L,V,L_G,alpha,w_MEA,y_CO2,y_H2O_input,y_H2O_legacy_converter,Tl_K,Tv_K,y_H2O_used
+1,single,srp,explicit,error,False,,1.7546692000000803,1.7546692000000803,60.0,"Traceback (most recent call last):
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 452, in <module>
+    raise SystemExit(main())
+                     ^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 422, in main
+    result = _run_worker(args.row_index, args.method, args.geometry, args.water_mode)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 248, in _run_worker
+    capture_pct, success = run_model_module.run_model(
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Run_Model.py""",28.64360773540634,3.777578223070945,7.58253199377055,0.2856469999645027,0.2918733806302769,0.1673103512648684,0.0158094828065687,0.1610531142152654,311.3692878203966,319.4556992586939,0.0158094828065687
+2,single,srp,explicit,success,True,99.99122971194558,0.8809951999996883,2.4635362000003624,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",29.070479136739003,3.62803646563233,8.012730691137724,0.2933976966191603,0.2950261386728167,0.1736239794367795,0.0114741599485045,0.1671306191119814,312.69085426120785,318.2188145208372,0.0114741599485045
+3,single,srp,explicit,success,True,99.99834683404384,0.7220311999999467,2.182947100000092,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",30.178120088425874,3.4130247037084662,8.842045607122458,0.2895122775062148,0.3112882218375913,0.1707334270232804,0.0149018071552836,0.1643481704202116,313.32454901962194,317.0452734646136,0.0149018071552836
+4,single,srp,explicit,success,True,99.9926607096554,0.9876241000001756,2.460339700000077,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / Tc_MEA) + c4_MEA * (Tl / Tc_MEA) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:101: RuntimeWarning: invalid value encountered",31.601498360355595,3.858418705807453,8.190271914448005,0.2771478557524129,0.2856822429794839,0.1738564128844092,0.0137994334129065,0.1673543597849616,314.71908159388266,321.790792540703,0.0137994334129065
+5,single,srp,explicit,success,True,99.99832062251292,0.7057058000000325,2.166026400000192,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",26.09447858767712,3.121052582266759,8.360794283294391,0.2904938834212728,0.2965053573331498,0.1830791105595,0.0107601414202209,0.1762321379427985,313.5238488184918,319.9583122402921,0.0107601414202209
+6,single,srp,explicit,success,True,99.9990597545618,0.70047889999978,2.16015490000018,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",30.5510693046463,3.1104189943339486,9.822171662499242,0.2959774486056234,0.3042864953078547,0.1664355107759593,0.0129011133259358,0.1602109918712786,312.2030956787332,318.09731313569495,0.0129011133259358
+7,single,srp,explicit,success,True,99.99948879604852,0.8853008999999474,2.345166600000084,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / Tc_MEA) + c4_MEA * (Tl / Tc_MEA) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:101: RuntimeWarning: invalid value encountered",29.64786440068401,3.247631492675869,9.129072823547418,0.2748689672294521,0.3031331402408543,0.1838146911713965,0.0111359378403512,0.1769402085876013,316.99033226456834,322.0058531802492,0.0111359378403512
+8,single,srp,explicit,success,True,99.99959638774271,0.729318499999863,2.188234299999749,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",27.659830329307045,3.2981712657077336,8.386414197739272,0.2665708488973907,0.3165620070370446,0.1656310709687484,0.011947296216853,0.1594366372950639,314.9950236381161,319.29116486059564,0.011947296216853
+9,single,srp,explicit,error,False,,1.662770899999941,1.662770899999941,60.0,"Traceback (most recent call last):
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 452, in <module>
+    raise SystemExit(main())
+                     ^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 422, in main
+    result = _run_worker(args.row_index, args.method, args.geometry, args.water_mode)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 248, in _run_worker
+    capture_pct, success = run_model_module.run_model(
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Run_Model.py""",27.83654811754617,3.672922774553986,7.578854723109838,0.2938359055490854,0.2909238582807239,0.1821079360336417,0.0118964905861627,0.1752972843569112,315.74153656601663,320.8708222432993,0.0118964905861627
+10,single,srp,explicit,error,False,,1.646520799999962,1.646520799999962,60.0,"Traceback (most recent call last):
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 452, in <module>
+    raise SystemExit(main())
+                     ^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 422, in main
+    result = _run_worker(args.row_index, args.method, args.geometry, args.water_mode)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 248, in _run_worker
+    capture_pct, success = run_model_module.run_model(
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Run_Model.py""",26.54225993893724,3.683581415948169,7.205558108210064,0.2840744221649599,0.3093693864794469,0.1783333963179011,0.0133697228263885,0.1716639085893423,314.5064803131476,321.2851857303846,0.0133697228263885
+11,single,srp,explicit,success,True,99.99803541501436,0.7092038999999204,2.200195800000074,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)",29.528134097326365,3.333938726595659,8.85683166933246,0.2837663775026199,0.2933401112820886,0.1847766395957819,0.0141300680763378,0.1778661811188314,313.06310866280506,317.67064634067884,0.0141300680763378
+12,single,srp,explicit,success,True,99.99804939416916,0.712646500000119,2.1714257999997244,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",30.998091543463687,3.463358817330929,8.950297436219058,0.2630568759109422,0.280210827256967,0.1772687772420542,0.0101691616757115,0.1706391051846403,313.79004290589535,322.4718296321292,0.0101691616757115
+13,single,srp,explicit,success,True,99.9942040257942,0.7740793000002668,2.254124900000079,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)",27.278642125247902,3.502059553131751,7.789314176811673,0.2793193549180117,0.2842692018202922,0.1686048517211839,0.0138458273774301,0.1622992016705038,311.9804770205678,317.33359756110576,0.0138458273774301
+14,single,srp,explicit,success,True,99.99707313362194,0.9205454000002646,2.440975399999843,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Pressure_Drop.py:30: RuntimeWarning: divide by zero encountered in scalar divide
+  ΔP_H = Ψ_L * a_p / (ϵ - h_L) ** 3 ** Fv ** 2 / 2 * 1 / K
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** ",26.8023989719814,3.538904370251016,7.573643186656748,0.2607828800573877,0.2826931200789466,0.1809395642302833,0.0153900827953073,0.1741726084712317,314.0065896514725,319.7515177792662,0.0153900827953073
+15,single,srp,explicit,success,True,99.99763031575128,0.9881274999997912,2.470874699999968,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / Tc_MEA) + c4_MEA * (Tl / Tc_MEA) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:101: RuntimeWarning: invalid value encountered in scalar power
+  sigma_H2O = c1_H2O * (1 - Tl / Tc_H2O) ** (c2_H2O + c3_H2O * (Tl / Tc_H2O) + c4_H2O * (Tl / Tc_H2O) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Pressure_Drop.py:30: RuntimeWarnin",31.446851602835466,3.926713215559541,8.008441125322776,0.2647864940946254,0.3056531854647496,0.167682382092376,0.0127163299570411,0.1614112314680307,316.3567210633908,320.5586446703595,0.0127163299570411
+16,single,srp,explicit,success,True,99.9982870600341,0.7011846999998852,2.16459470000018,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",26.475666321944924,3.004975294194757,8.81061031453159,0.2977160045953144,0.2882861858578072,0.169288358337634,0.0145329015667652,0.1629571458343515,315.35175228223227,318.78943473899017,0.0145329015667652
+17,single,srp,explicit,error,False,,1.6345424999999525,1.6345424999999525,60.0,"Traceback (most recent call last):
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 452, in <module>
+    raise SystemExit(main())
+                     ^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 422, in main
+    result = _run_worker(args.row_index, args.method, args.geometry, args.water_mode)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 248, in _run_worker
+    capture_pct, success = run_model_module.run_model(
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Run_Model.py""",30.56293074746814,3.998529518589053,7.643542608697002,0.2709035761091949,0.2878818444877855,0.1724617903463623,0.014750288343327,0.1660118947120644,314.1918830188118,322.88170029126763,0.014750288343327
+18,single,srp,explicit,success,True,99.99973069910916,0.7888264000002891,2.327380000000176,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",27.99778071164025,3.0465055757088524,9.190129483063822,0.2722611077870564,0.3146195392287275,0.1795182815325361,0.0125352605205452,0.1728044803015042,311.6683826048816,317.9493672698452,0.0125352605205452
+19,single,srp,explicit,success,True,99.99979715706178,1.1613055999996504,3.027725399999781,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",31.199176265318656,3.17824694785656,9.816473287690776,0.2653281070707639,0.3178994548687018,0.1700988854814213,0.0112048621185831,0.1637373600869431,312.55855996201905,321.5252965673215,0.0112048621185831
+20,single,srp,explicit,success,True,99.99780959799963,1.2920939000000544,3.162295099999937,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / Tc_MEA) + c4_MEA * (Tl / Tc_MEA) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:101: RuntimeWarning: invalid value encountered",28.579916221224074,3.8227288739387166,7.476312645677379,0.268941246487449,0.3184791683026847,0.1758738680058824,0.0132474857078458,0.1692963641358366,316.5267299138881,322.7255339880632,0.0132474857078458
+21,single,srp,explicit,success,True,99.99795523548111,1.0212824999998702,2.536984400000165,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / Tc_MEA) + c4_MEA * (Tl / Tc_MEA) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:101: RuntimeWarning: invalid value encountered",31.815442822173083,3.75891264944788,8.46400163803919,0.2731306662495792,0.3079479339044968,0.1817206659450787,0.0106054751293006,0.1749244977759617,315.8805789434772,318.56020994900683,0.0106054751293006
+22,single,srp,explicit,success,True,99.99883248301956,0.7185832000000119,2.262388000000101,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",29.930681531734308,3.3703152966694434,8.880676998176375,0.2878285342655778,0.3121672197082354,0.1718425808340712,0.010430539745467,0.1654158430060446,315.1772033484781,322.15635237565726,0.010430539745467
+23,single,srp,explicit,error,False,,2.181197599999905,2.181197599999905,60.0,"Traceback (most recent call last):
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 452, in <module>
+    raise SystemExit(main())
+                     ^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 422, in main
+    result = _run_worker(args.row_index, args.method, args.geometry, args.water_mode)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\analyses\legacy_srp_lhc_probe\scripts\run_legacy_srp_lhc.py"", line 248, in _run_worker
+    capture_pct, success = run_model_module.run_model(
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File ""C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Run_Model.py""",28.186610808100355,3.892572404345545,7.241126915618502,0.2813512937989418,0.3014263101443651,0.1750572198314629,0.015212879174635,0.1685102577729358,311.1993823860036,320.6080443100327,0.015212879174635
+24,single,srp,explicit,success,True,99.9939043992109,1.2184457000003022,3.1318327999997564,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / Tc_MEA) + c4_MEA * (Tl / Tc_MEA) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Pressure_Drop.py:30: RuntimeWarning: divide by zero encountered in scalar di",29.17772618930136,3.580758943487762,8.148475406970963,0.2993868204560651,0.2984005529970421,0.1762457694063917,0.0123952245534129,0.1696543568020418,316.1448982518156,320.20179118656824,0.0123952245534129
+25,single,srp,explicit,success,True,99.99868136333424,0.710019099999954,2.1779805999999557,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",27.127294421505137,3.219530283422651,8.425854715883082,0.2777336893410964,0.299921851740539,0.1792148769077188,0.0156751663922974,0.1725124227012139,311.83906200937275,319.0024084661446,0.0156751663922974
+1,single,srp,legacy-ratio,success,True,99.99728182234276,0.8073466000000735,2.279928099999779,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",28.64360773540634,3.777578223070945,7.58253199377055,0.2856469999645027,0.2918733806302769,0.1673103512648684,0.0158094828065687,0.1610531142152654,311.3692878203966,319.4556992586939,0.1610531142152654
+2,single,srp,legacy-ratio,success,True,99.9983575536574,0.7553564999998343,2.2058907999999064,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",29.070479136739003,3.62803646563233,8.012730691137724,0.2933976966191603,0.2950261386728167,0.1736239794367795,0.0114741599485045,0.1671306191119814,312.69085426120785,318.2188145208372,0.1671306191119814
+3,single,srp,legacy-ratio,success,True,99.99974795680836,0.7393859999997403,2.2188687000002574,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",30.178120088425874,3.4130247037084662,8.842045607122458,0.2895122775062148,0.3112882218375913,0.1707334270232804,0.0149018071552836,0.1643481704202116,313.32454901962194,317.0452734646136,0.1643481704202116
+4,single,srp,legacy-ratio,success,True,99.99879404767869,0.7385670000003302,2.20010289999982,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",31.601498360355595,3.858418705807453,8.190271914448005,0.2771478557524129,0.2856822429794839,0.1738564128844092,0.0137994334129065,0.1673543597849616,314.71908159388266,321.790792540703,0.1673543597849616
+5,single,srp,legacy-ratio,success,True,99.9997629646164,0.8988145999996959,2.3589559000001827,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",26.09447858767712,3.121052582266759,8.360794283294391,0.2904938834212728,0.2965053573331498,0.1830791105595,0.0107601414202209,0.1762321379427985,313.5238488184918,319.9583122402921,0.1762321379427985
+6,single,srp,legacy-ratio,success,True,99.99982238235064,0.8414599999996426,2.3127245999999104,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",30.5510693046463,3.1104189943339486,9.822171662499242,0.2959774486056234,0.3042864953078547,0.1664355107759593,0.0129011133259358,0.1602109918712786,312.2030956787332,318.09731313569495,0.1602109918712786
+7,single,srp,legacy-ratio,success,True,99.99987261497228,0.8558428999999705,2.3158023000000867,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",29.64786440068401,3.247631492675869,9.129072823547418,0.2748689672294521,0.3031331402408543,0.1838146911713965,0.0111359378403512,0.1769402085876013,316.99033226456834,322.0058531802492,0.1769402085876013
+8,single,srp,legacy-ratio,success,True,99.9998972628172,0.7346293999999034,2.1989582999999584,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",27.659830329307045,3.2981712657077336,8.386414197739272,0.2665708488973907,0.3165620070370446,0.1656310709687484,0.011947296216853,0.1594366372950639,314.9950236381161,319.29116486059564,0.1594366372950639
+9,single,srp,legacy-ratio,success,True,99.99700920613716,0.9825298999999176,2.455268799999885,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / Tc_MEA) + c4_MEA * (Tl / Tc_MEA) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:101: RuntimeWarning: invalid value encountered",27.83654811754617,3.672922774553986,7.578854723109838,0.2938359055490854,0.2909238582807239,0.1821079360336417,0.0118964905861627,0.1752972843569112,315.74153656601663,320.8708222432993,0.1752972843569112
+10,single,srp,legacy-ratio,success,True,99.99827521395856,0.9884005000003526,2.468661500000053,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / Tc_MEA) + c4_MEA * (Tl / Tc_MEA) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:101: RuntimeWarning: invalid value encountered",26.54225993893724,3.683581415948169,7.205558108210064,0.2840744221649599,0.3093693864794469,0.1783333963179011,0.0133697228263885,0.1716639085893423,314.5064803131476,321.2851857303846,0.1716639085893423
+11,single,srp,legacy-ratio,success,True,99.99964585771828,0.8666916000001947,2.3224508999996942,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",29.528134097326365,3.333938726595659,8.85683166933246,0.2837663775026199,0.2933401112820886,0.1847766395957819,0.0141300680763378,0.1778661811188314,313.06310866280506,317.67064634067884,0.1778661811188314
+12,single,srp,legacy-ratio,success,True,99.99977038106027,0.7315683000001627,2.199002500000006,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",30.998091543463687,3.463358817330929,8.950297436219058,0.2630568759109422,0.280210827256967,0.1772687772420542,0.0101691616757115,0.1706391051846403,313.79004290589535,322.4718296321292,0.1706391051846403
+13,single,srp,legacy-ratio,success,True,99.99888097295832,0.73203280000007,2.1913417999999183,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",27.278642125247902,3.502059553131751,7.789314176811673,0.2793193549180117,0.2842692018202922,0.1686048517211839,0.0138458273774301,0.1622992016705038,311.9804770205678,317.33359756110576,0.1622992016705038
+14,single,srp,legacy-ratio,success,True,99.99897593583876,1.0010879999999815,2.46964700000035,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:25: RuntimeWarning: invalid value encountered in scalar power
+  Ha = (k2 * Cl_MEA_true * Dl_CO2) ** .5 / kl_CO2
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_ME",26.8023989719814,3.538904370251016,7.573643186656748,0.2607828800573877,0.2826931200789466,0.1809395642302833,0.0153900827953073,0.1741726084712317,314.0065896514725,319.7515177792662,0.1741726084712317
+15,single,srp,legacy-ratio,success,True,99.9989867821288,0.9073803999999654,2.3870068999999603,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:25: RuntimeWarning: invalid value encountered in scalar power
+  Ha = (k2 * Cl_MEA_true * Dl_CO2) ** .5 / kl_CO2
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Pressure_Drop.py:30: RuntimeWarning: divide by zero encountered in scalar divide
+  ΔP_H = Ψ_L * a_p / (ϵ - h_L) ** 3 ** Fv ** 2 / 2 * 1 / K
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / ",31.446851602835466,3.926713215559541,8.008441125322776,0.2647864940946254,0.3056531854647496,0.167682382092376,0.0127163299570411,0.1614112314680307,316.3567210633908,320.5586446703595,0.1614112314680307
+16,single,srp,legacy-ratio,success,True,99.99969955935752,0.7314629000002242,2.193149600000197,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",26.475666321944924,3.004975294194757,8.81061031453159,0.2977160045953144,0.2882861858578072,0.169288358337634,0.0145329015667652,0.1629571458343515,315.35175228223227,318.78943473899017,0.1629571458343515
+17,single,srp,legacy-ratio,success,True,99.99585751759318,0.9542765000001054,2.4179933000000347,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Pressure_Drop.py:30: RuntimeWarning: divide by zero encountered in scalar divide
+  ΔP_H = Ψ_L * a_p / (ϵ - h_L) ** 3 ** Fv ** 2 / 2 * 1 / K
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** ",30.56293074746814,3.998529518589053,7.643542608697002,0.2709035761091949,0.2878818444877855,0.1724617903463623,0.014750288343327,0.1660118947120644,314.1918830188118,322.88170029126763,0.1660118947120644
+18,single,srp,legacy-ratio,success,True,99.99994749891454,0.8977201000002424,2.385695299999952,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",27.99778071164025,3.0465055757088524,9.190129483063822,0.2722611077870564,0.3146195392287275,0.1795182815325361,0.0125352605205452,0.1728044803015042,311.6683826048816,317.9493672698452,0.1728044803015042
+19,single,srp,legacy-ratio,success,True,99.99994954965588,0.8862002999999277,2.5276491999998143,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",31.199176265318656,3.17824694785656,9.816473287690776,0.2653281070707639,0.3178994548687018,0.1700988854814213,0.0112048621185831,0.1637373600869431,312.55855996201905,321.5252965673215,0.1637373600869431
+20,single,srp,legacy-ratio,success,True,99.9991211702958,0.958082099999956,2.4753718000001754,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / Tc_MEA) + c4_MEA * (Tl / Tc_MEA) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:101: RuntimeWarning: invalid value encountered",28.579916221224074,3.8227288739387166,7.476312645677379,0.268941246487449,0.3184791683026847,0.1758738680058824,0.0132474857078458,0.1692963641358366,316.5267299138881,322.7255339880632,0.1692963641358366
+21,single,srp,legacy-ratio,success,True,99.9997497993594,0.742113899999822,2.2672105999999985,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",31.815442822173083,3.75891264944788,8.46400163803919,0.2731306662495792,0.3079479339044968,0.1817206659450787,0.0106054751293006,0.1749244977759617,315.8805789434772,318.56020994900683,0.1749244977759617
+22,single,srp,legacy-ratio,success,True,99.99980155192917,0.7379928000000291,2.2410329999997884,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",29.930681531734308,3.3703152966694434,8.880676998176375,0.2878285342655778,0.3121672197082354,0.1718425808340712,0.010430539745467,0.1654158430060446,315.1772033484781,322.15635237565726,0.1654158430060446
+23,single,srp,legacy-ratio,success,True,99.99827865576856,0.8277401999998801,2.3859316999996736,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",28.186610808100355,3.892572404345545,7.241126915618502,0.2813512937989418,0.3014263101443651,0.1750572198314629,0.015212879174635,0.1685102577729358,311.1993823860036,320.6080443100327,0.1685102577729358
+24,single,srp,legacy-ratio,success,True,99.9979285109812,0.9350430999998024,2.516914600000291,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:100: RuntimeWarning: invalid value encountered in scalar power
+  sigma_MEA = c1_MEA * (1 - Tl / Tc_MEA) ** (c2_MEA + c3_MEA * (Tl / Tc_MEA) + c4_MEA * (Tl / Tc_MEA) ** 2)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Properties\Thermophysical_Properties.py:101: RuntimeWarning: invalid value encountered",29.17772618930136,3.580758943487762,8.148475406970963,0.2993868204560651,0.2984005529970421,0.1762457694063917,0.0123952245534129,0.1696543568020418,316.1448982518156,320.20179118656824,0.1696543568020418
+25,single,srp,legacy-ratio,success,True,99.99982735169992,0.8481825000003482,2.291170100000272,60.0,"C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\src\mea_absorption_column\Transport\Enhancement_Factor.py:44: RuntimeWarning: invalid value encountered in scalar power
+  eq1 = E - Ha * Υ_MEA_int ** (1 / 2) * (1 - Υ_CO2_int) / (1 - Υ_CO2_bulk)
+C:\Users\Tanner\.codex\worktrees\legacy-srp-lhc-probe\MEA-Absorption-Column\.venv\Lib\site-packages\scipy\optimize\_nonlin.py:374: RuntimeWarning: invalid value encountered in scalar divide
+  and dx_norm/self.x_rtol <= x_norm))",27.127294421505137,3.219530283422651,8.425854715883082,0.2777336893410964,0.299921851740539,0.1792148769077188,0.0156751663922974,0.1725124227012139,311.83906200937275,319.0024084661446,0.1725124227012139

--- a/analyses/legacy_srp_lhc_probe/results/legacy_srp_lhc_report.md
+++ b/analyses/legacy_srp_lhc_probe/results/legacy_srp_lhc_report.md
@@ -1,0 +1,17 @@
+# Legacy SRP-LHC Probe Results
+
+Rows tested: 50
+
+```text
+geometry   water_mode method  status  runs  median_runtime_s  median_wall_runtime_s  median_capture_pct
+     srp     explicit single   error     5          1.662771               1.662771                 NaN
+     srp     explicit single success    20          0.781453               2.294884           99.998168
+     srp legacy-ratio single success    25          0.848183               2.315802           99.999646
+```
+
+Notes:
+- `single` is the legacy shooting-method path.
+- The `srp` geometry mode uses the SRP dimensions already present in `Constants.py`.
+- `explicit` uses the SRP-LHC `y_H2O` column; `legacy-ratio` reproduces the old converter's fixed CO2-water ratio.
+- `y_H2O_input`, `y_H2O_legacy_converter`, and `y_H2O_used` are reported so the inlet-water assumption is visible.
+- Interpretation for the manuscript: shooting is fast for smoother SRP-like cases, finite difference can be useful as an intermediate method, and collocation remains the more defensible reference method for NCCC-style validation because it handles coupled boundary conditions and sharper thermal behavior more systematically.

--- a/analyses/legacy_srp_lhc_probe/results/legacy_srp_lhc_summary.csv
+++ b/analyses/legacy_srp_lhc_probe/results/legacy_srp_lhc_summary.csv
@@ -1,0 +1,4 @@
+geometry,water_mode,method,status,runs,median_runtime_s,median_wall_runtime_s,median_capture_pct
+srp,explicit,single,error,5,1.662770899999941,1.662770899999941,
+srp,explicit,single,success,20,0.781452850000278,2.2948840000001383,99.99816822710163
+srp,legacy-ratio,single,success,25,0.8481825000003482,2.3158023000000867,99.99964585771828

--- a/analyses/legacy_srp_lhc_probe/scripts/run_legacy_srp_lhc.py
+++ b/analyses/legacy_srp_lhc_probe/scripts/run_legacy_srp_lhc.py
@@ -1,0 +1,499 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import subprocess
+import sys
+import time
+import types
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOT = REPO_ROOT / "src"
+DATA_PATH = SRC_ROOT / "mea_absorption_column" / "data" / "LHC_design_w_SRP_cases.csv"
+DEFAULT_RESULTS_DIR = REPO_ROOT / "analyses" / "legacy_srp_lhc_probe" / "results"
+
+
+def _install_pcsaft_import_shim() -> None:
+    """Provide the unused legacy pcsaft symbols needed for import-time setup."""
+    if "pcsaft" in sys.modules:
+        return
+
+    module = types.ModuleType("pcsaft")
+
+    class InputError(Exception):
+        pass
+
+    def pcsaft_den(*args, **kwargs):
+        return 1.0
+
+    def pcsaft_fugcoef(*args, **kwargs):
+        x = kwargs.get("x")
+        if x is None and len(args) >= 3:
+            x = args[2]
+        n = len(x) if x is not None else 1
+        return np.ones(n)
+
+    module.InputError = InputError
+    module.pcsaft_den = pcsaft_den
+    module.pcsaft_fugcoef = pcsaft_fugcoef
+    sys.modules["pcsaft"] = module
+
+
+def _load_lhc() -> pd.DataFrame:
+    df = pd.read_csv(DATA_PATH)
+    return df.sort_values("Run").reset_index(drop=True)
+
+
+def _legacy_input_frame(lhc: pd.DataFrame) -> pd.DataFrame:
+    """Map SRP-LHC columns to the legacy run_model input shape."""
+    mapped = pd.DataFrame(
+        {
+            "L_G": lhc["L"] / lhc["V"],
+            "Fv_T": lhc["V"],
+            "alpha": lhc["alpha"],
+            "w_MEA_unloaded": lhc["w_MEA"],
+            "y_CO2": lhc["y_CO2"],
+            "Tl_z": lhc["Tl"],
+            "Tv_0": lhc["Tv"],
+            "P": 109180.0,
+            "beds": 1.0,
+            "y_H2O_explicit": lhc["y_H2O"],
+        }
+    )
+    return mapped
+
+
+def _row_metadata(row_index: int) -> dict[str, object]:
+    row = _load_lhc().iloc[row_index]
+    return {
+        "run": int(row["Run"]),
+        "L": float(row["L"]),
+        "V": float(row["V"]),
+        "L_G": float(row["L"] / row["V"]),
+        "alpha": float(row["alpha"]),
+        "w_MEA": float(row["w_MEA"]),
+        "y_CO2": float(row["y_CO2"]),
+        "y_H2O_input": float(row["y_H2O"]),
+        "y_H2O_legacy_converter": float(row["y_CO2"] * 0.9626010166),
+        "Tl_K": float(row["Tl"]),
+        "Tv_K": float(row["Tv"]),
+    }
+
+
+def _probe_convert_data(
+    df: pd.DataFrame,
+    run: int = 0,
+    type: str = "mole",
+    geometry: str = "srp",
+    water_mode: str = "explicit",
+):
+    """Legacy convert_data equivalent with selectable SRP vapor-water handling."""
+    if type != "mole":
+        raise ValueError("The SRP-LHC probe only supports mole inputs.")
+
+    from mea_absorption_column.config.Constants import MWs_l, MWs_v, column_params, packing_params, n
+
+    row = df.iloc[run]
+    L_G = float(row["L_G"])
+    Fv_T = float(row["Fv_T"])
+    alpha = float(row["alpha"])
+    w_MEA_unloaded = float(row["w_MEA_unloaded"])
+    y_CO2 = float(row["y_CO2"])
+    Tl_z = float(row["Tl_z"])
+    Tv_0 = float(row["Tv_0"])
+    P = float(row["P"])
+    beds = float(row["beds"])
+    if water_mode == "explicit":
+        y_H2O = float(row["y_H2O_explicit"])
+    elif water_mode == "legacy-ratio":
+        y_H2O = y_CO2 * 0.9626010166
+    else:
+        raise ValueError(f"Unknown water mode: {water_mode}")
+
+    MW_CO2 = MWs_l[0]
+    MW_MEA = MWs_l[1]
+    MW_H2O = MWs_l[2]
+    MW_N2 = MWs_v[2]
+    MW_O2 = MWs_v[3]
+
+    alpha_O2_N2 = 0.08485753604
+
+    Fl_T = L_G * Fv_T
+    x_MEA_unloaded = w_MEA_unloaded / (MW_MEA / MW_H2O + w_MEA_unloaded * (1 - MW_MEA / MW_H2O))
+    x_H2O_unloaded = 1 - x_MEA_unloaded
+
+    Fl_MEA_b = Fl_T * x_MEA_unloaded
+    Fl_H2O_b = Fl_T * x_H2O_unloaded
+    Fl_CO2_b = Fl_MEA_b * alpha
+    Fl = [Fl_CO2_b, Fl_MEA_b, Fl_H2O_b]
+
+    y_N2 = (1 - y_CO2 - y_H2O) / (1 + alpha_O2_N2)
+    y_O2 = y_N2 * alpha_O2_N2
+    if min(y_CO2, y_H2O, y_N2, y_O2) <= 0:
+        raise ValueError(
+            f"Invalid vapor composition for row {run + 1}: "
+            f"CO2={y_CO2}, H2O={y_H2O}, N2={y_N2}, O2={y_O2}"
+        )
+
+    Fv_CO2_a = y_CO2 * Fv_T
+    Fv_H2O_a = y_H2O * Fv_T
+    Fv_N2_a = y_N2 * Fv_T
+    Fv_O2_a = y_O2 * Fv_T
+    Fv = [Fv_CO2_a, Fv_H2O_a, Fv_N2_a, Fv_O2_a]
+
+    geometry_key = "SRP" if geometry == "srp" else "NCCC"
+    D = column_params[geometry_key]["D"]
+    H = column_params[geometry_key]["H"] * beds
+
+    packing_data = packing_params["MellapakPlus252Y"]
+    packing = (
+        packing_data["a_p"],
+        packing_data["eps"],
+        packing_data["Cl"],
+        packing_data["Cv"],
+        packing_data["Cs"],
+        packing_data["Cp_0"],
+        packing_data["Ch"],
+    )
+
+    A = np.pi * 0.25 * D**2
+    z = np.linspace(0, 1, n)
+    X = (L_G, Fv_T, alpha, w_MEA_unloaded, y_CO2, Tl_z, Tv_0, P, beds)
+    return [Fl, Fv, Tl_z, Tv_0, z, H, A, P, packing], X
+
+
+def _bounded_single_shoot_solve(Y_a_scaled, Y_b_scaled, z, parameters):
+    """Runner-local bounded shooting probe around the legacy Euler/ABS kernel."""
+    from scipy.optimize import least_squares
+    from mea_absorption_column.BVP.ABS_Column import abs_column
+    from mea_absorption_column.BVP.Methods.Integration_Methods import eulers
+
+    Fl_CO2_a_guess, Fl_H2O_a_guess, Fv_CO2_a, Fv_H2O_a, Hlf_a_guess, Hvf_a, P_a = Y_a_scaled
+    Fl_CO2_b, Fl_H2O_b, _Fv_CO2_b_guess, _Fv_H2O_b_guess, Hlf_b, _Hvf_b_guess, _P_b = Y_b_scaled
+    target = np.array([Fl_CO2_b, Fl_H2O_b, Hlf_b], dtype=float)
+    scale = np.maximum(np.abs(target), 1.0)
+    x0 = np.array([Fl_CO2_a_guess, Fl_H2O_a_guess, Hlf_a_guess], dtype=float)
+
+    h_low = min(0.2 * Hlf_a_guess, 5.0 * Hlf_a_guess)
+    h_high = max(0.2 * Hlf_a_guess, 5.0 * Hlf_a_guess)
+    lower = np.array([1.0e-12, 1.0e-12, h_low], dtype=float)
+    upper = np.array([max(10.0 * Fl_CO2_a_guess, 1.0), max(10.0 * Fl_H2O_a_guess, 1.0), h_high], dtype=float)
+    x0 = np.clip(x0, lower + 1.0e-12, upper - 1.0e-12)
+
+    def residual(x):
+        Y_a_trial = [x[0], x[1], Fv_CO2_a, Fv_H2O_a, x[2], Hvf_a, P_a]
+        try:
+            with np.errstate(all="ignore"):
+                Y_scaled, _, _, _ = eulers(abs_column, Y_a_trial, z, args=parameters)
+        except Exception:
+            return np.array([1.0e6, 1.0e6, 1.0e6])
+        if not np.all(np.isfinite(Y_scaled)):
+            return np.array([1.0e6, 1.0e6, 1.0e6])
+        simulated = np.array([Y_scaled[0, -1], Y_scaled[1, -1], Y_scaled[4, -1]], dtype=float)
+        if not np.all(np.isfinite(simulated)):
+            return np.array([1.0e6, 1.0e6, 1.0e6])
+        return (simulated - target) / scale
+
+    result = least_squares(
+        residual,
+        x0,
+        bounds=(lower, upper),
+        loss="soft_l1",
+        max_nfev=80,
+        xtol=1.0e-8,
+        ftol=1.0e-8,
+        gtol=1.0e-8,
+    )
+
+    Fl_CO2_a, Fl_H2O_a, Hlf_a = result.x
+    Y_a_final = [Fl_CO2_a, Fl_H2O_a, Fv_CO2_a, Fv_H2O_a, Hlf_a, Hvf_a, P_a]
+    Y_scaled, z, _success, _message = eulers(abs_column, Y_a_final, z, args=parameters)
+    residual_norm = float(np.linalg.norm(residual(result.x), ord=np.inf))
+    success = bool(result.success and np.all(np.isfinite(Y_scaled)) and residual_norm < 1.0e-2)
+    message = f"{result.message}; scaled_residual_inf={residual_norm:.3e}; nfev={result.nfev}"
+    return Y_scaled, z, "Bounded Single Shooting Probe", success, message
+
+
+def _run_worker(row_index: int, method: str, geometry: str, water_mode: str) -> dict[str, object]:
+    sys.path.insert(0, str(SRC_ROOT))
+    _install_pcsaft_import_shim()
+
+    import mea_absorption_column.Run_Model as run_model_module
+
+    if geometry not in {"srp", "legacy-nccc"}:
+        raise ValueError(f"Unknown geometry mode: {geometry}")
+
+    lhc = _load_lhc()
+    model_input = _legacy_input_frame(lhc)
+    row = lhc.iloc[row_index]
+    run_model_module.convert_data = lambda df, run=0, type="mole": _probe_convert_data(
+        df, run=run, type=type, geometry=geometry, water_mode=water_mode
+    )
+    method_for_run = method
+    if method == "single-bounded":
+        run_model_module.single_shoot_solve = _bounded_single_shoot_solve
+        method_for_run = "single"
+
+    start = time.perf_counter()
+    captured_stdout = io.StringIO()
+    with contextlib.redirect_stdout(captured_stdout), contextlib.redirect_stderr(captured_stdout):
+        capture_pct, success = run_model_module.run_model(
+            model_input,
+            method=method_for_run,
+            data_type="mole",
+            run=row_index,
+            show_info=False,
+            save_run_results=False,
+            plot_temperature=False,
+        )
+    runtime_s = time.perf_counter() - start
+
+    return {
+        "run": int(row["Run"]),
+        "method": method,
+        "geometry": geometry,
+        "water_mode": water_mode,
+        "status": "success" if bool(success) else "solver_failure",
+        "success": bool(success),
+        "capture_pct": float(capture_pct),
+        "runtime_s": runtime_s,
+        "message": captured_stdout.getvalue().strip()[:1000],
+        "L": float(row["L"]),
+        "V": float(row["V"]),
+        "L_G": float(row["L"] / row["V"]),
+        "alpha": float(row["alpha"]),
+        "w_MEA": float(row["w_MEA"]),
+        "y_CO2": float(row["y_CO2"]),
+        "y_H2O_input": float(row["y_H2O"]),
+        "y_H2O_legacy_converter": float(row["y_CO2"] * 0.9626010166),
+        "y_H2O_used": float(row["y_H2O"] if water_mode == "explicit" else row["y_CO2"] * 0.9626010166),
+        "Tl_K": float(row["Tl"]),
+        "Tv_K": float(row["Tv"]),
+    }
+
+
+def _run_subprocess(row_index: int, method: str, geometry: str, water_mode: str, timeout_s: float) -> dict[str, object]:
+    cmd = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--worker",
+        "--row-index",
+        str(row_index),
+        "--method",
+        method,
+        "--geometry",
+        geometry,
+        "--water-mode",
+        water_mode,
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC_ROOT)
+    start = time.perf_counter()
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired:
+        runtime_s = time.perf_counter() - start
+        result = {
+            "run": row_index + 1,
+            "method": method,
+            "geometry": geometry,
+            "water_mode": water_mode,
+            "status": "timeout",
+            "success": False,
+            "capture_pct": np.nan,
+            "runtime_s": runtime_s,
+            "wall_runtime_s": runtime_s,
+            "timeout_s": timeout_s,
+            "message": f"Timed out after {timeout_s:.1f} s",
+        }
+        result.update(_row_metadata(row_index))
+        result["y_H2O_used"] = result["y_H2O_input"] if water_mode == "explicit" else result["y_H2O_legacy_converter"]
+        return result
+
+    runtime_s = time.perf_counter() - start
+    if proc.returncode != 0:
+        result = {
+            "run": row_index + 1,
+            "method": method,
+            "geometry": geometry,
+            "water_mode": water_mode,
+            "status": "error",
+            "success": False,
+            "capture_pct": np.nan,
+            "runtime_s": runtime_s,
+            "wall_runtime_s": runtime_s,
+            "timeout_s": timeout_s,
+            "message": (proc.stderr or proc.stdout).strip()[:1000],
+        }
+        result.update(_row_metadata(row_index))
+        result["y_H2O_used"] = result["y_H2O_input"] if water_mode == "explicit" else result["y_H2O_legacy_converter"]
+        return result
+
+    try:
+        row = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        result = {
+            "run": row_index + 1,
+            "method": method,
+            "geometry": geometry,
+            "water_mode": water_mode,
+            "status": "bad_worker_output",
+            "success": False,
+            "capture_pct": np.nan,
+            "runtime_s": runtime_s,
+            "wall_runtime_s": runtime_s,
+            "timeout_s": timeout_s,
+            "message": proc.stdout.strip()[:1000],
+        }
+        result.update(_row_metadata(row_index))
+        result["y_H2O_used"] = result["y_H2O_input"] if water_mode == "explicit" else result["y_H2O_legacy_converter"]
+        return result
+    row["wall_runtime_s"] = runtime_s
+    row["timeout_s"] = timeout_s
+    return row
+
+
+def _write_outputs(rows: list[dict[str, object]], output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    results = pd.DataFrame(rows)
+    results_path = output_dir / "legacy_srp_lhc_matrix.csv"
+    results.to_csv(results_path, index=False)
+
+    summary = (
+        results.groupby(["geometry", "water_mode", "method", "status"], dropna=False)
+        .agg(
+            runs=("run", "count"),
+            median_runtime_s=("runtime_s", "median"),
+            median_wall_runtime_s=("wall_runtime_s", "median"),
+            median_capture_pct=("capture_pct", "median"),
+        )
+        .reset_index()
+    )
+    summary.to_csv(output_dir / "legacy_srp_lhc_summary.csv", index=False)
+
+    lines = [
+        "# Legacy SRP-LHC Probe Results",
+        "",
+        f"Rows tested: {len(results)}",
+        "",
+        "```text",
+        summary.to_string(index=False),
+        "```",
+        "",
+        "Notes:",
+        "- `single` is the legacy shooting-method path.",
+        "- The `srp` geometry mode uses the SRP dimensions already present in `Constants.py`.",
+        "- `explicit` uses the SRP-LHC `y_H2O` column; `legacy-ratio` reproduces the old converter's fixed CO2-water ratio.",
+        "- `y_H2O_input`, `y_H2O_legacy_converter`, and `y_H2O_used` are reported so the inlet-water assumption is visible.",
+        "- Interpretation for the manuscript: shooting is fast for smoother SRP-like cases, finite difference can be useful as an intermediate method, and collocation remains the more defensible reference method for NCCC-style validation because it handles coupled boundary conditions and sharper thermal behavior more systematically.",
+    ]
+    (output_dir / "legacy_srp_lhc_report.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _validate_existing_outputs(output_dir: Path) -> None:
+    summary_path = output_dir / "legacy_srp_lhc_summary.csv"
+    matrix_path = output_dir / "legacy_srp_lhc_matrix.csv"
+    bounded_path = output_dir / "bounded_failed_rows" / "legacy_srp_lhc_summary.csv"
+    missing = [path for path in [summary_path, matrix_path, bounded_path] if not path.exists()]
+    if missing:
+        raise FileNotFoundError("Missing expected probe artifact(s): " + ", ".join(str(path) for path in missing))
+
+    summary = pd.read_csv(summary_path)
+    required = {
+        ("srp", "explicit", "single", "success"): 20,
+        ("srp", "explicit", "single", "error"): 5,
+        ("srp", "legacy-ratio", "single", "success"): 25,
+    }
+    for key, expected_runs in required.items():
+        geometry, water_mode, method, status = key
+        rows = summary[
+            (summary["geometry"] == geometry)
+            & (summary["water_mode"] == water_mode)
+            & (summary["method"] == method)
+            & (summary["status"] == status)
+        ]
+        if rows.empty:
+            raise AssertionError(f"Missing summary row for {key}")
+        actual_runs = int(rows.iloc[0]["runs"])
+        if actual_runs != expected_runs:
+            raise AssertionError(f"Expected {expected_runs} runs for {key}, found {actual_runs}")
+
+    bounded = pd.read_csv(bounded_path)
+    rows = bounded[
+        (bounded["geometry"] == "srp")
+        & (bounded["water_mode"] == "explicit")
+        & (bounded["method"] == "single-bounded")
+        & (bounded["status"] == "solver_failure")
+    ]
+    if rows.empty or int(rows.iloc[0]["runs"]) != 5:
+        raise AssertionError("Expected five bounded-probe failures for explicit-water failed rows.")
+    print(f"Validated legacy SRP-LHC probe artifacts in {output_dir}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--methods", nargs="+", default=["single"], choices=["single", "single-bounded", "collocation", "finite"])
+    parser.add_argument("--geometry", default="srp", choices=["srp", "legacy-nccc"])
+    parser.add_argument("--water-modes", nargs="+", default=["explicit"], choices=["explicit", "legacy-ratio"])
+    parser.add_argument("--timeout-s", type=float, default=60.0)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--rows", nargs="+", type=int, default=None, help="1-based SRP-LHC Run numbers to execute.")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_RESULTS_DIR)
+    parser.add_argument("--validate-results-only", action="store_true")
+    parser.add_argument("--worker", action="store_true")
+    parser.add_argument("--row-index", type=int, default=0)
+    parser.add_argument("--method", default="single", choices=["single", "single-bounded", "collocation", "finite"])
+    parser.add_argument("--water-mode", default="explicit", choices=["explicit", "legacy-ratio"])
+    args = parser.parse_args()
+
+    if args.validate_results_only:
+        _validate_existing_outputs(args.output_dir)
+        return 0
+
+    if args.worker:
+        result = _run_worker(args.row_index, args.method, args.geometry, args.water_mode)
+        print(json.dumps(result))
+        return 0
+
+    n_rows = len(_load_lhc())
+    if args.rows:
+        row_indices = [row_number - 1 for row_number in args.rows]
+    else:
+        if args.limit is not None:
+            n_rows = min(n_rows, args.limit)
+        row_indices = list(range(n_rows))
+
+    rows: list[dict[str, object]] = []
+    for water_mode in args.water_modes:
+        for method in args.methods:
+            for row_index in row_indices:
+                result = _run_subprocess(row_index, method, args.geometry, water_mode, args.timeout_s)
+                rows.append(result)
+                print(
+                    f"{water_mode:12s} {method:11s} row {row_index + 1:02d}: "
+                    f"{result.get('status')} capture={result.get('capture_pct')} "
+                    f"runtime={result.get('runtime_s'):.2f}s"
+                )
+
+    _write_outputs(rows, args.output_dir)
+    print(f"Wrote {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a main-based legacy SRP-LHC probe analysis with committed result artifacts.
- Compare explicit SRP-LHC vapor water against the old legacy converter water-ratio assumption.
- Preserve the manuscript-facing interpretation that shooting is fast for smoother SRP-like cases, while collocation remains the stronger reference method for NCCC-style validation with sharper thermal behavior.

## Key result
- Explicit SRP-LHC vapor water: legacy shooting solved 20/25 rows, median successful model runtime 0.78 s.
- Legacy water-ratio assumption: legacy shooting solved 25/25 rows, median model runtime 0.85 s.
- The five explicit-water failures were not recovered by a bounded least-squares shooting probe, pointing to physical-domain conditioning rather than only Krylov root failure.

## Validation
- `python analyses/legacy_srp_lhc_probe/scripts/run_legacy_srp_lhc.py --validate-results-only`
- `git diff --check`
