### PR TITLE
Add optional pumparound temperature intercooling

### DIFF
--- a/src/mea_absorption_column/Run_Model.py
+++ b/src/mea_absorption_column/Run_Model.py
@@ -74,6 +74,19 @@ def run_model(df,
         if staged_beds != "auto"
         else method == "scipy-bvp" and (beds_count > 1 or intercoolers_count > 0)
     )
+    intercooler_settings = dict(intercooler_settings or {})
+    requested_intercooler_model = intercooler_settings.get(
+        "model",
+        solver_settings_for_run.get("intercooler_model", "liquid_temperature_reset"),
+    )
+    if (
+        method == "scipy-bvp"
+        and use_staged_beds
+        and intercoolers_count > 0
+        and requested_intercooler_model == "pumparound_temperature_approach"
+        and "thermal_state_mode" not in solver_settings_for_run
+    ):
+        solver_settings_for_run["thermal_state_mode"] = "temperature"
     thermal_state_mode = solver_settings_for_run.get("thermal_state_mode", "enthalpy")
     if (
         method == "scipy-bvp"
@@ -217,7 +230,6 @@ def run_model(df,
     }
     solver_diagnostics["_strict_domain_guards"] = bool(model_options["strict_domain_guards"])
     parameters = scales, eq_scales, const_flow, H, A, packing, model_options
-    intercooler_settings = intercooler_settings or {}
     stack_spec = build_bed_stack_spec(
         beds=beds_count if use_staged_beds else 1,
         intercoolers=intercoolers_count if use_staged_beds else 0,
@@ -225,6 +237,7 @@ def run_model(df,
         liquid_feed_temperature_K=Tl_z,
         target_temperatures_K=intercooler_settings.get("target_temperatures_K"),
         intercooler_strength=float(intercooler_settings.get("strength", solver_settings_for_run.get("intercooler_strength", 1.0))),
+        intercooler_model=requested_intercooler_model,
     )
     if (
         method == "scipy-bvp"
@@ -537,7 +550,8 @@ Run #{run + 1:03d}:
             'beds': beds_count,
             'intercoolers': intercoolers_count,
             'staged_beds': bool(use_staged_beds),
-            'intercooler_model': 'liquid_temperature_reset' if stack_spec.intercoolers else 'none',
+            'intercooler_model': stack_spec.model if stack_spec.intercoolers else 'none',
+            'thermal_state_mode': thermal_state_mode,
             'intercooler_assumption': (
                 f"{stack_spec.assumption};strength={stack_spec.intercoolers[0].strength:g}"
                 if stack_spec.intercoolers

--- a/src/mea_absorption_column/benchmark.py
+++ b/src/mea_absorption_column/benchmark.py
@@ -62,6 +62,7 @@ BENCHMARK_COLUMNS = [
     "intercoolers",
     "staged_beds",
     "intercooler_model",
+    "thermal_state_mode",
     "intercooler_assumption",
     "continuation_stage",
     "continuation_success",
@@ -814,6 +815,11 @@ def parse_args(argv=None):
     parser.add_argument("--mass-transfer-factor", type=float, default=None)
     parser.add_argument("--heat-transfer-factor", type=float, default=None)
     parser.add_argument("--intercooler-strength", type=float, default=None)
+    parser.add_argument(
+        "--intercooler-model",
+        choices=["liquid_temperature_reset", "pumparound_temperature_approach"],
+        default=None,
+    )
     parser.add_argument("--success-boundary-residual-max", type=float, default=None)
     parser.add_argument("--success-capture-error-max-pct", type=float, default=None)
     parser.add_argument("--capture-correction-model", default=None)
@@ -885,6 +891,8 @@ def _solver_settings_from_args(args):
         settings["transform_mode"] = args.transform_mode
     if args.thermal_state_mode is not None:
         settings["thermal_state_mode"] = args.thermal_state_mode
+    if args.intercooler_model is not None:
+        settings["intercooler_model"] = args.intercooler_model
     if args.co2_flux_mode is not None:
         settings["co2_flux_mode"] = args.co2_flux_mode
     if args.vapor_composition_mode is not None:

--- a/src/mea_absorption_column/intercooling.py
+++ b/src/mea_absorption_column/intercooling.py
@@ -22,6 +22,7 @@ class BedStackSpec:
     single_bed_height_m: float
     intercoolers: tuple[IntercoolerSpec, ...]
     assumption: str
+    model: str = "liquid_temperature_reset"
 
 
 def build_bed_stack_spec(
@@ -31,6 +32,7 @@ def build_bed_stack_spec(
     liquid_feed_temperature_K: float,
     target_temperatures_K: list[float] | tuple[float, ...] | None = None,
     intercooler_strength: float = 1.0,
+    intercooler_model: str = "liquid_temperature_reset",
 ) -> BedStackSpec:
     beds = int(beds)
     intercoolers = int(intercoolers)
@@ -43,6 +45,9 @@ def build_bed_stack_spec(
     intercooler_strength = float(intercooler_strength)
     if not 0.0 <= intercooler_strength <= 1.0:
         raise ValueError("intercooler_strength must be between 0 and 1.")
+    allowed_models = {"liquid_temperature_reset", "pumparound_temperature_approach"}
+    if intercooler_model not in allowed_models:
+        raise ValueError(f"intercooler_model must be one of {sorted(allowed_models)}.")
 
     if target_temperatures_K is None:
         targets = [float(liquid_feed_temperature_K)] * intercoolers
@@ -58,7 +63,11 @@ def build_bed_stack_spec(
         specs.append(
             IntercoolerSpec(
                 below_upper_bed_index=beds - 1 - offset,
-                mode="temperature_target",
+                mode=(
+                    "pumparound_temperature_approach"
+                    if intercooler_model == "pumparound_temperature_approach"
+                    else "temperature_target"
+                ),
                 target_temperature_K=targets[offset],
                 strength=intercooler_strength,
             )
@@ -69,6 +78,7 @@ def build_bed_stack_spec(
         single_bed_height_m=float(single_bed_height_m),
         intercoolers=tuple(specs),
         assumption=assumption,
+        model=intercooler_model,
     )
 
 

--- a/tests/test_benchmarking.py
+++ b/tests/test_benchmarking.py
@@ -177,6 +177,7 @@ def test_benchmark_schema_includes_staged_bed_metadata():
         "intercoolers",
         "staged_beds",
         "intercooler_model",
+        "thermal_state_mode",
         "intercooler_assumption",
         "mass_transfer_factor",
         "heat_transfer_factor",
@@ -247,6 +248,8 @@ def test_benchmark_cli_accepts_solver_settings():
         "0.5",
         "--heat-transfer-factor",
         "0.8",
+        "--intercooler-model",
+        "pumparound_temperature_approach",
         "--success-boundary-residual-max",
         "0.5",
         "--success-capture-error-max-pct",
@@ -295,6 +298,7 @@ def test_benchmark_cli_accepts_solver_settings():
     assert args.eta_psi == 1.0
     assert args.mass_transfer_factor == 0.5
     assert args.heat_transfer_factor == 0.8
+    assert args.intercooler_model == "pumparound_temperature_approach"
     assert args.success_boundary_residual_max == 0.5
     assert args.success_capture_error_max_pct == 8
     assert args.capture_correction_model == "nccc_linear"
@@ -313,6 +317,7 @@ def test_benchmark_cli_accepts_solver_settings():
     assert solver_settings["h2o_capture_guess_pct"] == -90
     assert solver_settings["epcsaft_fugacity_blend"] == 0.5
     assert solver_settings["eta_psi"] == 1.0
+    assert solver_settings["intercooler_model"] == "pumparound_temperature_approach"
     assert solver_settings["vapor_composition_mode"] == "input_o2"
     assert solver_settings["gas_flow_basis"] == "reported_dry_mass"
     assert solver_settings["gas_velocity_area_exponent"] == 1.5

--- a/tests/test_intercooling.py
+++ b/tests/test_intercooling.py
@@ -64,6 +64,49 @@ def test_build_bed_stack_spec_accepts_intercooler_strength():
     assert all(cooler.strength == 0.25 for cooler in spec.intercoolers)
 
 
+def test_build_bed_stack_spec_accepts_pumparound_temperature_approach():
+    from mea_absorption_column.intercooling import build_bed_stack_spec
+
+    spec = build_bed_stack_spec(
+        beds=3,
+        intercoolers=2,
+        single_bed_height_m=6.1,
+        liquid_feed_temperature_K=314.0,
+        intercooler_model="pumparound_temperature_approach",
+    )
+
+    assert spec.model == "pumparound_temperature_approach"
+    assert all(cooler.mode == "pumparound_temperature_approach" for cooler in spec.intercoolers)
+
+
+def test_pumparound_model_selects_temperature_state_for_staged_run(monkeypatch):
+    import mea_absorption_column.Run_Model as run_model_module
+
+    df = pd.read_csv("src/mea_absorption_column/data/NCCC_Data.csv", index_col=0)
+    run = list(df.index).index("K3")
+
+    def fake_solver(y_a, y_b, z, _parameters, stack_spec, settings=None):
+        assert settings["thermal_state_mode"] == "temperature"
+        profile = np.vstack([np.column_stack([y_a, y_b])] * stack_spec.beds)
+        return profile, np.array([z[0], z[-1]]), "fake", True, "fake success"
+
+    monkeypatch.setattr(run_model_module, "scaling", lambda _z, y: np.maximum(np.abs(y), 1.0))
+    monkeypatch.setattr(run_model_module, "segmented_scipy_BVP_solve", fake_solver)
+
+    result = run_model_module.run_model(
+        df,
+        method="scipy-bvp",
+        run=run,
+        thermo_model="ideal_henry",
+        return_details=True,
+        intercooler_settings={"model": "pumparound_temperature_approach"},
+    )
+
+    assert result["success"] is True
+    assert result["thermal_state_mode"] == "temperature"
+    assert result["intercooler_model"] == "pumparound_temperature_approach"
+
+
 def test_liquid_enthalpy_after_intercooler_preserves_liquid_molar_flows():
     from mea_absorption_column.intercooling import liquid_enthalpy_after_intercooler
 


### PR DESCRIPTION
Adds the accepted minimal portion of the historical intercooler experiment:

- keeps liquid-temperature reset as the unchanged default
- adds an opt-in pumparound temperature-approach selector
- automatically uses temperature-state solving for that staged/intercooled option
- exposes the selector through the benchmark CLI and records model/state provenance
- excludes the rejected distributed-cooling implementation and generated evidence artifacts

Validation:
- 44 focused tests passed
- 110 repository tests passed; 25 ePC-SAFT-native tests skipped because the immutable native wheel is not installed in this rebuilt environment
- K3 diagnostic invocation exercised the option and provenance but timed out at the 60 s gate, so this PR makes no accepted scientific-performance claim